### PR TITLE
IGP95

### DIFF
--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -783,7 +783,7 @@ contract PayloadIGP95 is PayloadIGPMain {
                     tokenA: wstETH_ADDRESS,
                     tokenB: ETH_ADDRESS,
                     smartCollateral: true,
-                    smartDebt: false,
+                    smartDebt: true,
                     baseWithdrawalLimitInUSD: 20_000_000, // $20M
                     baseBorrowLimitInUSD: 26_000_000, // $26M
                     maxBorrowLimitInUSD: 51_000_000 // $51M

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -816,26 +816,20 @@ contract PayloadIGP95 is PayloadIGPMain {
         }
 
         {
-            // weETH-ETH T2 vault
-            address weETH_ETH__wstETH_VAULT = getVaultAddress(74);
-            {
-                // Update max borrow to 45.5M$
-                VaultConfig memory VAULT_weETH_ETH = VaultConfig({
-                    vault: weETH_ETH__wstETH_VAULT,
-                    vaultType: VAULT_TYPE.TYPE_2,
-                    supplyToken: address(0),
-                    borrowToken: ETH_ADDRESS,
-                    baseWithdrawalLimitInUSD: 0,
-                    baseBorrowLimitInUSD: 0,
-                    maxBorrowLimitInUSD: 45_500_000 // 45.5M$
-                });
-
-                setVaultLimits(VAULT_weETH_ETH); // TYPE_2 => 74
-            }
+            // weETH-ETH DEX
+            address WEETH_ETH_DEX = getDexAddress(14);
             {
                 // Update max supply shares
-                IFluidDex(weETH_ETH__wstETH_VAULT).updateMaxSupplyShares(
+                IFluidDex(WEETH_ETH_DEX).updateMaxSupplyShares(
                     10_000 * 1e18 // ~48M
+                );
+            }
+            {
+                // Update Range
+                IFluidDex(WEETH_ETH_DEX).updateRangePercents(
+                    0.0001 * 1e4, // +0.0001%
+                    0.07 * 1e4, // -0.07%
+                    0
                 );
             }
         }

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -459,7 +459,7 @@ contract PayloadIGP95 is PayloadIGPMain {
         }
         {
             IFluidDex(RLP_USDC_DEX).updateMaxSupplyShares(
-                5_000_000 * 1e18 // $5M
+                5_000_000 * 1e18 // $10M
             );
         }
     }
@@ -476,17 +476,17 @@ contract PayloadIGP95 is PayloadIGPMain {
                     tokenB: XAUT_ADDRESS,
                     smartCollateral: true,
                     smartDebt: false,
-                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseWithdrawalLimitInUSD: 1_200_000, // $1.2M
                     baseBorrowLimitInUSD: 0, // $0
                     maxBorrowLimitInUSD: 0 // $0
                 });
                 setDexLimits(DEX_PAXG_XAUT); // Smart Collateral
 
-                DEX_FACTORY.setDexAuth(PAXG_XAUT_DEX, TEAM_MULTISIG, false);
+                DEX_FACTORY.setDexAuth(PAXG_XAUT_DEX, TEAM_MULTISIG, true);
             }
             {
                 IFluidDex(PAXG_XAUT_DEX).updateMaxSupplyShares(
-                    1_800_000 * 1e18 // $1.8M
+                    280 * 1e18 // $1.8M
                 );
             }
         }
@@ -500,9 +500,9 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: XAUT_ADDRESS,
                     borrowToken: USDC_ADDRESS,
-                    baseWithdrawalLimitInUSD: 750_000, // $750k
-                    baseBorrowLimitInUSD: 750_000, // $750k
-                    maxBorrowLimitInUSD: 1_400_000 // $1.4M
+                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
                 setVaultLimits(VAULT_XAUT_USDC); // TYPE_1 => 116
@@ -524,9 +524,9 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: XAUT_ADDRESS,
                     borrowToken: USDT_ADDRESS,
-                    baseWithdrawalLimitInUSD: 750_000, // $750k
-                    baseBorrowLimitInUSD: 750_000, // $750k
-                    maxBorrowLimitInUSD: 1_400_000 // $1.4M
+                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
                 setVaultLimits(VAULT_XAUT_USDT); // TYPE_1 => 117
@@ -548,9 +548,9 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: XAUT_ADDRESS,
                     borrowToken: GHO_ADDRESS,
-                    baseWithdrawalLimitInUSD: 750_000, // $750k
-                    baseBorrowLimitInUSD: 750_000, // $750k
-                    maxBorrowLimitInUSD: 1_400_000 // $1.4M
+                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
                 setVaultLimits(VAULT_XAUT_GHO); // TYPE_1 => 118
@@ -715,16 +715,6 @@ contract PayloadIGP95 is PayloadIGPMain {
     function action10() internal isActionSkippable(10) {
         address sUSDe_USDC_VAULT = getVaultAddress(7);
         {
-            // Set supply protocol limits
-            SupplyProtocolConfig memory supplyConfig_ = SupplyProtocolConfig({
-                protocol: sUSDe_USDC_VAULT,
-                supplyToken: sUSDe_ADDRESS,
-                expandPercent: 1 * 1e2, // 1%
-                expandDuration: 720 hours, // 720 hours
-                baseWithdrawalLimitInUSD: 0 // $0
-            });
-            setSupplyProtocolLimits(supplyConfig_);
-
             // Set borrow protocol limits
             BorrowProtocolConfig memory borrowConfig_ = BorrowProtocolConfig({
                 protocol: sUSDe_USDC_VAULT,
@@ -736,6 +726,17 @@ contract PayloadIGP95 is PayloadIGPMain {
             });
             setBorrowProtocolLimits(borrowConfig_);
         }
+    }
+
+    // @notice Action 11: Update Borrow Limits for sUSDe/USDC
+    function action11() internal isActionSkippable(11) {
+        address USD0_USDC_DEX = getDexAddress(4);
+
+        IFluidDex(USD0_USDC_DEX).updateRangePercents(
+            0.05 * 1e4, // upper range: 0.05%
+            0.5 * 1e4, // lower range: 0.5%
+            2 days
+        );
     }
 
     /**

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -99,7 +99,7 @@ contract PayloadIGP95 is PayloadIGPMain {
                 // sUSDe-GHO DEX
                 {
                     // sUSDe-GHO Dex
-                    Dex memory DEX_sUSDe_GHO = Dex({
+                    DexConfig memory DEX_sUSDe_GHO = DexConfig({
                         dex: sUSDe_GHO_DEX,
                         tokenA: sUSDe_ADDRESS,
                         tokenB: GHO_ADDRESS,
@@ -758,7 +758,7 @@ contract PayloadIGP95 is PayloadIGPMain {
 
         // Spell 1: Deposit stETH into Lite
         {
-            uint256 STETH_AMOUNT = IERC20(STETH_ADDRESS).balanceOf(TREASURY);
+            uint256 STETH_AMOUNT = IERC20(stETH_ADDRESS).balanceOf(address(TREASURY));
             targets[0] = "BASIC-D-V2";
             encodedSpells[0] = abi.encodeWithSignature(
                 depositSignature,
@@ -817,7 +817,7 @@ contract PayloadIGP95 is PayloadIGPMain {
 
         {
             // weETH-ETH DEX
-            address WEETH_ETH_DEX = getDexAddress(14);
+            address WEETH_ETH_DEX = getDexAddress(9);
             {
                 // Update max supply shares
                 IFluidDex(WEETH_ETH_DEX).updateMaxSupplyShares(

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -582,8 +582,8 @@ contract PayloadIGP95 is PayloadIGPMain {
                     supplyToken: PAXG_ADDRESS,
                     borrowToken: USDC_ADDRESS,
                     baseWithdrawalLimitInUSD: 5_000_000, // $5M
-                    baseBorrowLimitInUSD: 1_500_000, // $1.5M
-                    maxBorrowLimitInUSD: 1_500_000 // $1.5M
+                    baseBorrowLimitInUSD: 2_500_000, // $2.5M
+                    maxBorrowLimitInUSD: 2_500_000 // $2.5M
                 });
 
                 setVaultLimits(VAULT_PAXG_USDC); // TYPE_1 => 119
@@ -606,8 +606,8 @@ contract PayloadIGP95 is PayloadIGPMain {
                     supplyToken: PAXG_ADDRESS,
                     borrowToken: USDT_ADDRESS,
                     baseWithdrawalLimitInUSD: 5_000_000, // $5M
-                    baseBorrowLimitInUSD: 1_500_000, // $1.5M
-                    maxBorrowLimitInUSD: 1_500_000 // $1.5M
+                    baseBorrowLimitInUSD: 2_500_000, // $2.5M
+                    maxBorrowLimitInUSD: 2_500_000 // $2.5M
                 });
 
                 setVaultLimits(VAULT_PAXG_USDT); // TYPE_1 => 120
@@ -629,8 +629,8 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: PAXG_ADDRESS,
                     borrowToken: GHO_ADDRESS,
-                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    baseWithdrawalLimitInUSD: 5_000_000, // $5M
+                    baseBorrowLimitInUSD: 2_500_000, // $2.5M
                     maxBorrowLimitInUSD: 2_500_000 // $2.5M
                 });
 
@@ -655,7 +655,7 @@ contract PayloadIGP95 is PayloadIGPMain {
                     supplyToken: address(0),
                     borrowToken: USDC_ADDRESS,
                     baseWithdrawalLimitInUSD: 0,
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 2_000_000, // $2M
                     maxBorrowLimitInUSD: 2_000_000 // $2M
                 });
 
@@ -680,7 +680,7 @@ contract PayloadIGP95 is PayloadIGPMain {
                     supplyToken: address(0),
                     borrowToken: USDT_ADDRESS,
                     baseWithdrawalLimitInUSD: 0,
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 2_000_000, // $2M
                     maxBorrowLimitInUSD: 2_000_000 // $2M
                 });
 
@@ -705,7 +705,7 @@ contract PayloadIGP95 is PayloadIGPMain {
                     supplyToken: address(0),
                     borrowToken: GHO_ADDRESS,
                     baseWithdrawalLimitInUSD: 0,
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 2_000_000, // $2M
                     maxBorrowLimitInUSD: 2_000_000 // $2M
                 });
 

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -1,0 +1,888 @@
+pragma solidity ^0.8.21;
+pragma experimental ABIEncoderV2;
+
+import {BigMathMinified} from "../libraries/bigMathMinified.sol";
+import {LiquidityCalcs} from "../libraries/liquidityCalcs.sol";
+import {LiquiditySlotsLink} from "../libraries/liquiditySlotsLink.sol";
+
+import {IGovernorBravo} from "../common/interfaces/IGovernorBravo.sol";
+import {ITimelock} from "../common/interfaces/ITimelock.sol";
+
+import {IFluidLiquidityAdmin, AdminModuleStructs as FluidLiquidityAdminStructs} from "../common/interfaces/IFluidLiquidity.sol";
+import {IFluidReserveContract} from "../common/interfaces/IFluidReserveContract.sol";
+
+import {IFluidVaultFactory} from "../common/interfaces/IFluidVaultFactory.sol";
+import {IFluidDexFactory} from "../common/interfaces/IFluidDexFactory.sol";
+
+import {IFluidDex, IFluidAdminDex, IFluidDexResolver} from "../common/interfaces/IFluidDex.sol";
+
+import {IFluidVault, IFluidVaultT1} from "../common/interfaces/IFluidVault.sol";
+
+import {IFTokenAdmin, ILendingRewards} from "../common/interfaces/IFToken.sol";
+
+import {ISmartLendingAdmin} from "../common/interfaces/ISmartLending.sol";
+import {ISmartLendingFactory} from "../common/interfaces/ISmartLendingFactory.sol";
+import {IFluidLendingFactory} from "../common/interfaces/IFluidLendingFactory.sol";
+
+import {ICodeReader} from "../common/interfaces/ICodeReader.sol";
+
+import {IDSAV2} from "../common/interfaces/IDSA.sol";
+import {IERC20} from "../common/interfaces/IERC20.sol";
+import {IProxy} from "../common/interfaces/IProxy.sol";
+import {PayloadIGPConstants} from "../common/constants.sol";
+import {PayloadIGPHelpers} from "../common/helpers.sol";
+import {PayloadIGPMain} from "../common/main.sol";
+
+contract PayloadIGP95 is PayloadIGPMain {
+    uint256 public constant PROPOSAL_ID = 95;
+
+    function execute() public virtual override {
+        super.execute();
+
+        // Action 1: Set dust limits for sUSDe-GHO and USDC-GHO DEXes
+        action1();
+
+        // Action 2: Set dust limits for sUSDe-GHO/USDC-GHO T4 vault
+        action2();
+
+        // Action 3: Reduce allowance of fUSDC and fUSDT
+        action3();
+
+        // Action 4: Remove Borrow Rewards handlers as Vault Auth
+        action4();
+
+        // Action 5: Remove Team Multisig as Auth on Unlaunched Vaults
+        action5();
+
+        // Action 6: Pause Limits for Unlaunched USDe Collateral Vaults
+        action6();
+
+        // Action 7: Pause Limits for Bugged DEXes
+        action7();
+
+        // Action 8: Set Launch Limits for RLP-USDC DEX
+        action8();
+
+        // Action 9: Set Launch Limits for Gold Vaults and DEX
+        action9();
+
+        // Action 10: Update Borrow Limits for sUSDe/USDC
+        action10();
+    }
+
+    function verifyProposal() public view override {}
+
+    function _PROPOSAL_ID() internal view override returns (uint256) {
+        return PROPOSAL_ID;
+    }
+
+    /**
+     * |
+     * |     Proposal Payload Actions      |
+     * |__________________________________
+     */
+
+    // @notice Action 1: Set dust limits for sUSDe-GHO and USDC-GHO DEXes
+    function action1() internal isActionSkippable(1) {
+        {
+            address sUSDe_GHO_DEX = getDexAddress(33);
+            {
+                // sUSDe-GHO DEX
+                {
+                    // sUSDe-GHO Dex
+                    Dex memory DEX_sUSDe_GHO = Dex({
+                        dex: sUSDe_GHO_DEX,
+                        tokenA: sUSDe_ADDRESS,
+                        tokenB: GHO_ADDRESS,
+                        smartCollateral: true,
+                        smartDebt: false,
+                        baseWithdrawalLimitInUSD: 10_000, // $10k
+                        baseBorrowLimitInUSD: 0, // $0
+                        maxBorrowLimitInUSD: 0 // $0
+                    });
+                    setDexLimits(DEX_sUSDe_GHO); // Smart Collateral
+
+                    DEX_FACTORY.setDexAuth(sUSDe_GHO_DEX, TEAM_MULTISIG, true);
+                }
+            }
+        }
+
+        {
+            address USDC_GHO_DEX = getDexAddress(34);
+            {
+                // USDC-GHO DEX
+                {
+                    // USDC-GHO Dex
+                    Dex memory DEX_USDC_GHO = Dex({
+                        dex: USDC_GHO_DEX,
+                        tokenA: USDC_ADDRESS,
+                        tokenB: GHO_ADDRESS,
+                        smartCollateral: false,
+                        smartDebt: true,
+                        baseWithdrawalLimitInUSD: 0, // $0
+                        baseBorrowLimitInUSD: 10_000, // $10k
+                        maxBorrowLimitInUSD: 10_000 // $10k
+                    });
+                    setDexLimits(DEX_USDC_GHO); // Smart Debt
+
+                    DEX_FACTORY.setDexAuth(USDC_GHO_DEX, TEAM_MULTISIG, true);
+                }
+            }
+        }
+    }
+
+    // @notice Action 2: Set dust limits for sUSDe-GHO/USDC-GHO T4 vault
+    function action2() internal isActionSkippable(2) {
+        {
+            //sUSDe/GHO : USDC/GHO
+            address sUSDe_GHO_DEX_ADDRESS = getDexAddress(33);
+            address USDC_GHO_DEX_ADDRESS = getDexAddress(34);
+            address sUSDe_GHO__USDC_GHO_VAULT_ADDRESS = getVaultAddress(125);
+
+            {
+                // Update sUSDe-GHO<>USDC-GHO vault supply shares limit
+                IFluidAdminDex.UserSupplyConfig[]
+                    memory config_ = new IFluidAdminDex.UserSupplyConfig[](1);
+                config_[0] = IFluidAdminDex.UserSupplyConfig({
+                    user: sUSDe_GHO__USDC_GHO_VAULT_ADDRESS,
+                    expandPercent: 35 * 1e2, // 35%
+                    expandDuration: 6 hours, // 6 hours
+                    baseWithdrawalLimit: 5_000 * 1e18 // 5k shares ($10k)
+                });
+
+                IFluidDex(sUSDe_GHO_DEX_ADDRESS).updateUserSupplyConfigs(
+                    config_
+                );
+            }
+
+            {
+                // Update sUSDe-GHO<>USDC-GHO vault borrow shares limit
+                IFluidAdminDex.UserBorrowConfig[]
+                    memory config_ = new IFluidAdminDex.UserBorrowConfig[](1);
+                config_[0] = IFluidAdminDex.UserBorrowConfig({
+                    user: sUSDe_GHO__USDC_GHO_VAULT_ADDRESS,
+                    expandPercent: 30 * 1e2, // 30%
+                    expandDuration: 6 hours, // 6 hours
+                    baseDebtCeiling: 4_000 * 1e18, // 4k shares ($8k)
+                    maxDebtCeiling: 5_000 * 1e18 // 5k shares ($10k)
+                });
+
+                IFluidDex(USDC_GHO_DEX_ADDRESS).updateUserBorrowConfigs(
+                    config_
+                );
+            }
+
+            VAULT_FACTORY.setVaultAuth(
+                sUSDe_GHO__USDC_GHO_VAULT_ADDRESS,
+                TEAM_MULTISIG,
+                true
+            );
+        }
+    }
+
+    // @notice Action 3: Reduce allowance of fUSDC and fUSDT
+    function action3() internal isActionSkippable(3) {
+        address[] memory protocols = new address[](2);
+        address[] memory tokens = new address[](2);
+        uint256[] memory amounts = new uint256[](2);
+
+        {
+            /// fUSDC
+            uint256 allowance = IERC20(USDC_ADDRESS).allowance(
+                address(FLUID_RESERVE),
+                F_USDC_ADDRESS
+            );
+
+            protocols[0] = F_USDC_ADDRESS;
+            tokens[0] = USDC_ADDRESS;
+            amounts[0] = 1_200_000 * 1e6; // 1.2M
+        }
+
+        {
+            /// fUSDT
+            uint256 allowance = IERC20(USDT_ADDRESS).allowance(
+                address(FLUID_RESERVE),
+                F_USDT_ADDRESS
+            );
+
+            protocols[1] = F_USDT_ADDRESS;
+            tokens[1] = USDT_ADDRESS;
+            amounts[1] = 1_200_000 * 1e6; // 1.2M
+        }
+    }
+
+    // @notice Action 4: Reduce allowance of fUSDC and fUSDT
+    function action4() internal isActionSkippable(4) {
+        {
+            address cbBTC_USDC = getVaultAddress(29);
+
+            // Fee Handler Addresses
+            address FeeHandler = 0x7110cED08f0E26c14a2eF7A980c4F17C70aBa7c0;
+
+            // Remove handler as auth
+            VAULT_FACTORY.setVaultAuth(cbBTC_USDC, FeeHandler, false);
+        }
+
+        {
+            address cbBTC_USDT = getVaultAddress(30);
+
+            // Fee Handler Addresses
+            address FeeHandler = 0xf5fD6c6f936689018215CB10d7a5b99A43a39D28;
+
+            // Remove handler as auth
+            VAULT_FACTORY.setVaultAuth(cbBTC_USDT, FeeHandler, false);
+        }
+
+        {
+            address wBTC_USDT = getVaultAddress(22);
+
+            // Fee Handler Addresses
+            address FeeHandler = 0x6D90d460929b921f6C74838a9d25CC69B486D605;
+
+            // Remove handler as auth
+            VAULT_FACTORY.setVaultAuth(wBTC_USDT, FeeHandler, false);
+        }
+
+        {
+            address wBTC_USDC = getVaultAddress(21);
+
+            // Fee Handler Addresses
+            address FeeHandler = 0x5E5768B6b42c12dA8e75eb0AA6fD47Be33a5b24e;
+
+            // Remove handler as auth
+            VAULT_FACTORY.setVaultAuth(wBTC_USDC, FeeHandler, false);
+        }
+    }
+
+    // @notice Action 5: Remove Team Multisig as Auth on Unlaunched Vaults
+    function action5() internal isActionSkippable(5) {
+        {
+            address USDC_ETH__USDC_ETH = getVaultAddress(62);
+
+            VAULT_FACTORY.setVaultAuth(
+                USDC_ETH__USDC_ETH,
+                TEAM_MULTISIG,
+                false
+            );
+        }
+        {
+            address WBTC_ETH__WBTC_ETH = getVaultAddress(63);
+
+            VAULT_FACTORY.setVaultAuth(
+                WBTC_ETH__WBTC_ETH,
+                TEAM_MULTISIG,
+                false
+            );
+        }
+        {
+            address cbBTC_ETH__cbBTC_ETH = getVaultAddress(64);
+
+            VAULT_FACTORY.setVaultAuth(
+                cbBTC_ETH__cbBTC_ETH,
+                TEAM_MULTISIG,
+                false
+            );
+        }
+        {
+            address USDe_USDC__USDe_USDC = getVaultAddress(65);
+
+            VAULT_FACTORY.setVaultAuth(
+                cbBTC_ETH__cbBTC_ETH,
+                TEAM_MULTISIG,
+                false
+            );
+        }
+        {
+            address FLUID_ETH__ETH = getVaultAddress(75);
+
+            VAULT_FACTORY.setVaultAuth(FLUID_ETH__ETH, TEAM_MULTISIG, false);
+        }
+    }
+
+    // @notice Action 6: Pause Limits for Unlaunched USDe Collateral Vaults
+    function action6() internal isActionSkippable(6) {
+        {
+            address USDe_USDC = getVaultAddress(66);
+            // Pause supply and borrow limits
+            setSupplyProtocolLimitsPaused(USDe_USDC, USDe_ADDRESS);
+            setBorrowProtocolLimitsPaused(USDe_USDC, USDC_ADDRESS);
+        }
+
+        {
+            address USDe_USDT = getVaultAddress(67);
+            // Pause supply and borrow limits
+            setSupplyProtocolLimitsPaused(USDe_USDT, USDe_ADDRESS);
+            setBorrowProtocolLimitsPaused(USDe_USDT, USDT_ADDRESS);
+        }
+
+        {
+            address USDe_GHO = getVaultAddress(68);
+            // Pause supply and borrow limits
+            setSupplyProtocolLimitsPaused(USDe_GHO, USDe_ADDRESS);
+            setBorrowProtocolLimitsPaused(USDe_GHO, GHO_ADDRESS);
+        }
+    }
+
+    // @notice Action 7: Pause Limits for Unlaunched USDe Collateral Vaults
+    function action7() internal isActionSkippable(7) {
+        {
+            address USDC_ETH_DEX = getDexAddress(5);
+            {
+                // USDC-ETH DEX
+                {
+                    setSupplyProtocolLimitsPaused(USDC_ETH_DEX, USDC_ADDRESS);
+
+                    setSupplyProtocolLimitsPaused(USDC_ETH_DEX, ETH_ADDRESS);
+                }
+                {
+                    setBorrowProtocolLimitsPaused(USDC_ETH_DEX, USDC_ADDRESS);
+
+                    setBorrowProtocolLimitsPaused(USDC_ETH_DEX, ETH_ADDRESS);
+                }
+            }
+
+            {
+                // Pause user supply and borrow
+                address[] memory supplyTokens = new address[](2);
+                supplyTokens[0] = USDC_ADDRESS;
+                supplyTokens[1] = ETH_ADDRESS;
+
+                address[] memory borrowTokens = new address[](2);
+                borrowTokens[0] = USDC_ADDRESS;
+                borrowTokens[1] = ETH_ADDRESS;
+
+                // Pause the user operations
+                LIQUIDITY.pauseUser(USDC_ETH_DEX, supplyTokens, borrowTokens);
+            }
+        }
+        {
+            address WBTC_ETH_DEX = getDexAddress(6);
+            {
+                // WBTC-ETH DEX
+                {
+                    setSupplyProtocolLimitsPaused(WBTC_ETH_DEX, WBTC_ADDRESS);
+
+                    setSupplyProtocolLimitsPaused(WBTC_ETH_DEX, ETH_ADDRESS);
+                }
+            }
+
+            {
+                // Pause user supply and borrow
+                address[] memory supplyTokens = new address[](2);
+                supplyTokens[0] = WBTC_ADDRESS;
+                supplyTokens[1] = ETH_ADDRESS;
+
+                address[] memory borrowTokens = new address[](0);
+
+                // Pause the user operations
+                LIQUIDITY.pauseUser(WBTC_ETH_DEX, supplyTokens, borrowTokens);
+            }
+        }
+        {
+            address cbBTC_ETH_DEX = getDexAddress(7);
+            {
+                // cbBTC-ETH DEX
+                {
+                    setSupplyProtocolLimitsPaused(cbBTC_ETH_DEX, cbBTC_ADDRESS);
+
+                    setSupplyProtocolLimitsPaused(cbBTC_ETH_DEX, ETH_ADDRESS);
+                }
+            }
+
+            {
+                // Pause user supply and borrow
+                address[] memory supplyTokens = new address[](2);
+                supplyTokens[0] = cbBTC_ADDRESS;
+                supplyTokens[1] = ETH_ADDRESS;
+
+                address[] memory borrowTokens = new address[](0);
+
+                // Pause the user operations
+                LIQUIDITY.pauseUser(cbBTC_ETH_DEX, supplyTokens, borrowTokens);
+            }
+        }
+        {
+            address USDe_USDC_DEX = getDexAddress(8);
+            {
+                // cbBTC-ETH DEX
+                {
+                    setSupplyProtocolLimitsPaused(USDe_USDC_DEX, USDe_ADDRESS);
+
+                    setSupplyProtocolLimitsPaused(USDe_USDC_DEX, USDC_ADDRESS);
+                }
+            }
+
+            {
+                // Pause user supply and borrow
+                address[] memory supplyTokens = new address[](2);
+                supplyTokens[0] = USDe_ADDRESS;
+                supplyTokens[1] = USDC_ADDRESS;
+
+                address[] memory borrowTokens = new address[](0);
+
+                // Pause the user operations
+                LIQUIDITY.pauseUser(USDe_USDC_DEX, supplyTokens, borrowTokens);
+            }
+        }
+
+        {
+            address FLUID_ETH_DEX = getDexAddress(8);
+            {
+                // cbBTC-ETH DEX
+                {
+                    setSupplyProtocolLimitsPaused(FLUID_ETH_DEX, FLUID_ADDRESS);
+
+                    setSupplyProtocolLimitsPaused(FLUID_ETH_DEX, ETH_ADDRESS);
+                }
+            }
+
+            {
+                // Pause user supply and borrow
+                address[] memory supplyTokens = new address[](2);
+                supplyTokens[0] = FLUID_ADDRESS;
+                supplyTokens[1] = ETH_ADDRESS;
+
+                address[] memory borrowTokens = new address[](0);
+
+                // Pause the user operations
+                LIQUIDITY.pauseUser(FLUID_ETH_DEX, supplyTokens, borrowTokens);
+            }
+        }
+    }
+
+    // @notice Action 8: Set Launch Limits for RLP-USDC DEX
+    function action8() internal isActionSkippable(8) {
+        address RLP_USDC_DEX = getDexAddress(28);
+        {
+            // RLP-USDC DEX
+            DexConfig memory DEX_RLP_USDC = DexConfig({
+                dex: RLP_USDC_DEX,
+                tokenA: RLP_ADDRESS,
+                tokenB: USDC_ADDRESS,
+                smartCollateral: true,
+                smartDebt: false,
+                baseWithdrawalLimitInUSD: 10_000_000, // $10M
+                baseBorrowLimitInUSD: 0, // $0
+                maxBorrowLimitInUSD: 0 // $0
+            });
+            setDexLimits(DEX_RLP_USDC); // Smart Collateral
+
+            DEX_FACTORY.setDexAuth(RLP_USDC_DEX, TEAM_MULTISIG, false);
+        }
+
+        {
+            address fSL28_RLP_USDC = getSmartLendingAddress(28);
+
+            // set rebalancer at fSL28 to reserve contract proxy
+            ISmartLendingAdmin(fSL28_RLP_USDC).setRebalancer(
+                address(FLUID_RESERVE)
+            );
+        }
+        {
+            IFluidDex(RLP_USDC_DEX).updateMaxSupplyShares(
+                7_500_000 * 1e18 // $7.5M
+            );
+        }
+    }
+
+    // @notice Action 9: Set Launch Limits for Gold Vaults and DEX
+    function action9() internal isActionSkippable(9) {
+        {
+            // PAXG-XAUT DEX
+            address PAXG_XAUT_DEX = getDexAddress(32);
+            {
+                DexConfig memory DEX_PAXG_XAUT = DexConfig({
+                    dex: PAXG_XAUT_DEX,
+                    tokenA: PAXG_ADDRESS,
+                    tokenB: XAUT_ADDRESS,
+                    smartCollateral: true,
+                    smartDebt: false,
+                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 0, // $0
+                    maxBorrowLimitInUSD: 0 // $0
+                });
+                setDexLimits(DEX_PAXG_XAUT); // Smart Collateral
+
+                DEX_FACTORY.setDexAuth(PAXG_XAUT_DEX, TEAM_MULTISIG, false);
+            }
+            {
+                IFluidDex(PAXG_XAUT_DEX).updateMaxSupplyShares(
+                    2_500_000 * 1e18 // $2.5M
+                );
+            }
+        }
+
+        {
+            // [TYPE 1] XAUT / USDC VAULT
+            address XAUT_USDC_VAULT = getVaultAddress(116);
+            {
+                VaultConfig memory VAULT_XAUT_USDC = VaultConfig({
+                    vault: XAUT_USDC_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_1,
+                    supplyToken: XAUT_ADDRESS,
+                    borrowToken: USDC_ADDRESS,
+                    baseWithdrawalLimitInUSD: 750_000, // $750k
+                    baseBorrowLimitInUSD: 750_000, // $750k
+                    maxBorrowLimitInUSD: 1_400_000 // $1.4M
+                });
+
+                setVaultLimits(VAULT_XAUT_USDC); // TYPE_1 => 116
+
+                VAULT_FACTORY.setVaultAuth(
+                    XAUT_USDC_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 1] XAUT / USDT VAULT
+            address XAUT_USDT_VAULT = getVaultAddress(117);
+            {
+                VaultConfig memory VAULT_XAUT_USDT = VaultConfig({
+                    vault: XAUT_USDT_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_1,
+                    supplyToken: XAUT_ADDRESS,
+                    borrowToken: USDT_ADDRESS,
+                    baseWithdrawalLimitInUSD: 750_000, // $750k
+                    baseBorrowLimitInUSD: 750_000, // $750k
+                    maxBorrowLimitInUSD: 1_400_000 // $1.4M
+                });
+
+                setVaultLimits(VAULT_XAUT_USDT); // TYPE_1 => 117
+
+                VAULT_FACTORY.setVaultAuth(
+                    XAUT_USDT_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 1] XAUT / GHO VAULT
+            address XAUT_GHO_VAULT = getVaultAddress(118);
+            {
+                VaultConfig memory VAULT_XAUT_GHO = VaultConfig({
+                    vault: XAUT_GHO_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_1,
+                    supplyToken: XAUT_ADDRESS,
+                    borrowToken: GHO_ADDRESS,
+                    baseWithdrawalLimitInUSD: 750_000, // $750k
+                    baseBorrowLimitInUSD: 750_000, // $750k
+                    maxBorrowLimitInUSD: 1_400_000 // $1.4M
+                });
+
+                setVaultLimits(VAULT_XAUT_GHO); // TYPE_1 => 118
+
+                VAULT_FACTORY.setVaultAuth(
+                    XAUT_GHO_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 1] PAXG / USDC VAULT
+            address PAXG_USDC_VAULT = getVaultAddress(119);
+            {
+                VaultConfig memory VAULT_PAXG_USDC = VaultConfig({
+                    vault: PAXG_USDC_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_1,
+                    supplyToken: PAXG_ADDRESS,
+                    borrowToken: USDC_ADDRESS,
+                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 2_500_000 // $2.5M
+                });
+
+                setVaultLimits(VAULT_PAXG_USDC); // TYPE_1 => 119
+
+                VAULT_FACTORY.setVaultAuth(
+                    PAXG_USDC_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 1] PAXG / USDT VAULT
+            address PAXG_USDT_VAULT = getVaultAddress(120);
+            {
+                VaultConfig memory VAULT_PAXG_USDT = VaultConfig({
+                    vault: PAXG_USDT_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_1,
+                    supplyToken: PAXG_ADDRESS,
+                    borrowToken: USDT_ADDRESS,
+                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 2_500_000 // $2.5M
+                });
+
+                setVaultLimits(VAULT_PAXG_USDT); // TYPE_1 => 120
+
+                VAULT_FACTORY.setVaultAuth(
+                    PAXG_USDT_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 1] PAXG / GHO VAULT
+            address PAXG_GHO_VAULT = getVaultAddress(121);
+            {
+                VaultConfig memory VAULT_PAXG_GHO = VaultConfig({
+                    vault: PAXG_GHO_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_1,
+                    supplyToken: PAXG_ADDRESS,
+                    borrowToken: GHO_ADDRESS,
+                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 2_500_000 // $2.5M
+                });
+
+                setVaultLimits(VAULT_PAXG_GHO); // TYPE_1 => 121
+
+                VAULT_FACTORY.setVaultAuth(
+                    PAXG_GHO_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 2] PAXG-XAUT<>USDC | smart collateral & normal debt
+            address PAXG_XAUT__USDC_VAULT = getVaultAddress(122);
+
+            {
+                VaultConfig memory VAULT_PAXG_XAUT__USDC = VaultConfig({
+                    vault: PAXG_XAUT__USDC_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_2,
+                    supplyToken: address(0),
+                    borrowToken: USDC_ADDRESS,
+                    baseWithdrawalLimitInUSD: 0,
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 2_000_000 // $2M
+                });
+
+                setVaultLimits(VAULT_PAXG_XAUT__USDC); // TYPE_2 => 122
+
+                VAULT_FACTORY.setVaultAuth(
+                    PAXG_XAUT__USDC_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 2] PAXG-XAUT<>USDT | smart collateral & normal debt
+            address PAXG_XAUT__USDT_VAULT = getVaultAddress(123);
+
+            {
+                VaultConfig memory VAULT_PAXG_XAUT__USDT = VaultConfig({
+                    vault: PAXG_XAUT__USDT_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_2,
+                    supplyToken: address(0),
+                    borrowToken: USDT_ADDRESS,
+                    baseWithdrawalLimitInUSD: 0,
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 2_000_000 // $2M
+                });
+
+                setVaultLimits(VAULT_PAXG_XAUT__USDT); // TYPE_2 => 123
+
+                VAULT_FACTORY.setVaultAuth(
+                    PAXG_XAUT__USDT_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+
+        {
+            // [TYPE 2] PAXG-XAUT<>GHO | smart collateral & normal debt
+            address PAXG_XAUT__GHO_VAULT = getVaultAddress(124);
+
+            {
+                VaultConfig memory VAULT_PAXG_XAUT__GHO = VaultConfig({
+                    vault: PAXG_XAUT__GHO_VAULT,
+                    vaultType: VAULT_TYPE.TYPE_2,
+                    supplyToken: address(0),
+                    borrowToken: GHO_ADDRESS,
+                    baseWithdrawalLimitInUSD: 0,
+                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    maxBorrowLimitInUSD: 2_000_000 // $2M
+                });
+
+                setVaultLimits(VAULT_PAXG_XAUT__GHO); // TYPE_2 => 124
+
+                VAULT_FACTORY.setVaultAuth(
+                    PAXG_XAUT__GHO_VAULT,
+                    TEAM_MULTISIG,
+                    false
+                );
+            }
+        }
+    }
+
+    // @notice Action 10: Update Borrow Limits for sUSDe/USDC
+    function action10() internal isActionSkippable(10) {
+        address sUSDe_USDC_VAULT = getVaultAddress(7);
+        {
+            VaultConfig memory VAULT_sUSDe_USDC = VaultConfig({
+                vault: sUSDe_USDC_VAULT,
+                vaultType: VAULT_TYPE.TYPE_1,
+                supplyToken: sUSDe_ADDRESS,
+                borrowToken: USDC_ADDRESS,
+                baseWithdrawalLimitInUSD: 0, // $0
+                baseBorrowLimitInUSD: 2_500, // $2.5k
+                maxBorrowLimitInUSD: 5_000 // $5k
+            });
+
+            setVaultLimits(VAULT_sUSDe_USDC);
+        }
+    }
+
+    /**
+     * |
+     * |     Payload Actions End Here      |
+     * |__________________________________
+     */
+
+    // Token Prices Constants
+    uint256 public constant ETH_USD_PRICE = 1_750 * 1e2;
+    uint256 public constant wstETH_USD_PRICE = 2_300 * 1e2;
+    uint256 public constant weETH_USD_PRICE = 2_000 * 1e2;
+    uint256 public constant rsETH_USD_PRICE = 1_975 * 1e2;
+    uint256 public constant weETHs_USD_PRICE = 1_930 * 1e2;
+    uint256 public constant mETH_USD_PRICE = 2_000 * 1e2;
+    uint256 public constant ezETH_USD_PRICE = 1_975 * 1e2;
+
+    uint256 public constant BTC_USD_PRICE = 94_500 * 1e2;
+
+    uint256 public constant STABLE_USD_PRICE = 1 * 1e2;
+    uint256 public constant sUSDe_USD_PRICE = 1.15 * 1e2;
+    uint256 public constant sUSDs_USD_PRICE = 1.02 * 1e2;
+
+    uint256 public constant FLUID_USD_PRICE = 5 * 1e2;
+
+    uint256 public constant RLP_USD_PRICE = 1.16 * 1e2;
+    uint256 public constant wstUSR_USD_PRICE = 1.07 * 1e2;
+
+    uint256 public constant XAUT_USD_PRICE = 3_400 * 1e2;
+    uint256 public constant PAXG_USD_PRICE = 3_400 * 1e2;
+
+    function getRawAmount(
+        address token,
+        uint256 amount,
+        uint256 amountInUSD,
+        bool isSupply
+    ) public view override returns (uint256) {
+        if (amount > 0 && amountInUSD > 0) {
+            revert("both usd and amount are not zero");
+        }
+        uint256 exchangePriceAndConfig_ = LIQUIDITY.readFromStorage(
+            LiquiditySlotsLink.calculateMappingStorageSlot(
+                LiquiditySlotsLink.LIQUIDITY_EXCHANGE_PRICES_MAPPING_SLOT,
+                token
+            )
+        );
+
+        (
+            uint256 supplyExchangePrice,
+            uint256 borrowExchangePrice
+        ) = LiquidityCalcs.calcExchangePrices(exchangePriceAndConfig_);
+
+        uint256 usdPrice = 0;
+        uint256 decimals = 18;
+        if (token == ETH_ADDRESS) {
+            usdPrice = ETH_USD_PRICE;
+            decimals = 18;
+        } else if (token == wstETH_ADDRESS) {
+            usdPrice = wstETH_USD_PRICE;
+            decimals = 18;
+        } else if (token == weETH_ADDRESS) {
+            usdPrice = weETH_USD_PRICE;
+            decimals = 18;
+        } else if (token == rsETH_ADDRESS) {
+            usdPrice = rsETH_USD_PRICE;
+            decimals = 18;
+        } else if (token == weETHs_ADDRESS) {
+            usdPrice = weETHs_USD_PRICE;
+            decimals = 18;
+        } else if (token == mETH_ADDRESS) {
+            usdPrice = mETH_USD_PRICE;
+            decimals = 18;
+        } else if (token == ezETH_ADDRESS) {
+            usdPrice = ezETH_USD_PRICE;
+            decimals = 18;
+        } else if (
+            token == cbBTC_ADDRESS ||
+            token == WBTC_ADDRESS ||
+            token == eBTC_ADDRESS ||
+            token == lBTC_ADDRESS
+        ) {
+            usdPrice = BTC_USD_PRICE;
+            decimals = 8;
+        } else if (token == tBTC_ADDRESS) {
+            usdPrice = BTC_USD_PRICE;
+            decimals = 18;
+        } else if (token == USDC_ADDRESS || token == USDT_ADDRESS) {
+            usdPrice = STABLE_USD_PRICE;
+            decimals = 6;
+        } else if (token == sUSDe_ADDRESS) {
+            usdPrice = sUSDe_USD_PRICE;
+            decimals = 18;
+        } else if (token == sUSDs_ADDRESS) {
+            usdPrice = sUSDs_USD_PRICE;
+            decimals = 18;
+        } else if (
+            token == GHO_ADDRESS ||
+            token == USDe_ADDRESS ||
+            token == deUSD_ADDRESS ||
+            token == USR_ADDRESS ||
+            token == USD0_ADDRESS ||
+            token == fxUSD_ADDRESS ||
+            token == BOLD_ADDRESS
+        ) {
+            usdPrice = STABLE_USD_PRICE;
+            decimals = 18;
+        } else if (token == INST_ADDRESS) {
+            usdPrice = FLUID_USD_PRICE;
+            decimals = 18;
+        } else if (token == wstUSR_ADDRESS) {
+            usdPrice = wstUSR_USD_PRICE;
+            decimals = 18;
+        } else if (token == RLP_ADDRESS) {
+            usdPrice = RLP_USD_PRICE;
+            decimals = 18;
+        } else if (token == XAUT_ADDRESS) {
+            usdPrice = XAUT_USD_PRICE;
+            decimals = 6;
+        } else if (token == PAXG_ADDRESS) {
+            usdPrice = PAXG_USD_PRICE;
+            decimals = 18;
+        } else {
+            revert("not-found");
+        }
+
+        uint256 exchangePrice = isSupply
+            ? supplyExchangePrice
+            : borrowExchangePrice;
+
+        if (amount > 0) {
+            return (amount * 1e12) / exchangePrice;
+        } else {
+            return
+                (amountInUSD * 1e12 * (10 ** decimals)) /
+                ((usdPrice * exchangePrice) / 1e2);
+        }
+    }
+}

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -790,6 +790,11 @@ contract PayloadIGP95 is PayloadIGPMain {
                 });
                 setDexLimits(DEX_WSTETH_ETH); // Smart Collateral
             }
+            {
+                // Set max supply and borrow shares
+                IFluidDex(WSTETH_ETH_DEX).updateMaxSupplyShares(9000 * 1e18);
+                IFluidDex(WSTETH_ETH_DEX).updateMaxBorrowShares(8100 * 1e18);
+            }
         }
 
         {
@@ -807,12 +812,6 @@ contract PayloadIGP95 is PayloadIGPMain {
                 });
 
                 setVaultLimits(VAULT_WSTETH_ETH); // TYPE_4 => 44
-            }
-            {
-                // Update max borrow shares
-                IFluidDex(WSTETH_ETH__WSTETH_ETH_VAULT).updateMaxBorrowShares(
-                    9_300 * 1e18
-                );
             }
         }
 

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -68,6 +68,12 @@ contract PayloadIGP95 is PayloadIGPMain {
 
         // Action 10: Update Borrow Limits for sUSDe/USDC
         action10();
+
+        // Action 11: Update Range Percentages for USD0-USDC DEX
+        action11();
+
+        // Action 12: Deposit ETH from Treasury to Lite
+        action12();
     }
 
     function verifyProposal() public view override {}
@@ -500,8 +506,8 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: XAUT_ADDRESS,
                     borrowToken: USDC_ADDRESS,
-                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    baseWithdrawalLimitInUSD: 5_000_000, // $5M
+                    baseBorrowLimitInUSD: 1_500_000, // $1.5M
                     maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
@@ -524,8 +530,8 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: XAUT_ADDRESS,
                     borrowToken: USDT_ADDRESS,
-                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    baseWithdrawalLimitInUSD: 5_000_000, // $5M
+                    baseBorrowLimitInUSD: 1_500_000, // $1.5M
                     maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
@@ -548,8 +554,8 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: XAUT_ADDRESS,
                     borrowToken: GHO_ADDRESS,
-                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
+                    baseWithdrawalLimitInUSD: 5_000_000, // $5M
+                    baseBorrowLimitInUSD: 1_500_000, // $1.5M
                     maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
@@ -572,9 +578,9 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: PAXG_ADDRESS,
                     borrowToken: USDC_ADDRESS,
-                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
-                    maxBorrowLimitInUSD: 2_500_000 // $2.5M
+                    baseWithdrawalLimitInUSD: 5_000_000, // $5M
+                    baseBorrowLimitInUSD: 1_500_000, // $1.5M
+                    maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
                 setVaultLimits(VAULT_PAXG_USDC); // TYPE_1 => 119
@@ -596,9 +602,9 @@ contract PayloadIGP95 is PayloadIGPMain {
                     vaultType: VAULT_TYPE.TYPE_1,
                     supplyToken: PAXG_ADDRESS,
                     borrowToken: USDT_ADDRESS,
-                    baseWithdrawalLimitInUSD: 1_000_000, // $1M
-                    baseBorrowLimitInUSD: 1_000_000, // $1M
-                    maxBorrowLimitInUSD: 2_500_000 // $2.5M
+                    baseWithdrawalLimitInUSD: 5_000_000, // $5M
+                    baseBorrowLimitInUSD: 1_500_000, // $1.5M
+                    maxBorrowLimitInUSD: 1_500_000 // $1.5M
                 });
 
                 setVaultLimits(VAULT_PAXG_USDT); // TYPE_1 => 120
@@ -728,15 +734,39 @@ contract PayloadIGP95 is PayloadIGPMain {
         }
     }
 
-    // @notice Action 11: Update Borrow Limits for sUSDe/USDC
+    // @notice Action 11: Update Range Percentages for USD0-USDC DEX
     function action11() internal isActionSkippable(11) {
-        address USD0_USDC_DEX = getDexAddress(4);
+        address USD0_USDC_DEX = getDexAddress(23);
 
         IFluidDex(USD0_USDC_DEX).updateRangePercents(
             0.05 * 1e4, // upper range: 0.05%
             0.5 * 1e4, // lower range: 0.5%
             2 days
         );
+    }
+
+    // @notice Action 12: Deposit ETH from Treasury to Lite
+    function action12() internal isActionSkippable(12) {
+        string[] memory targets = new string[](1);
+        bytes[] memory encodedSpells = new bytes[](1);
+
+        string
+            memory depositSignature = "deposit(address,uint256,uint256,uint256)";
+
+        // Spell 1: Deposit ETH into Lite
+        {
+            uint256 ETH_AMOUNT = 1_000_000 * 1e18; //
+            targets[0] = "BASIC-D-V2";
+            encodedSpells[0] = abi.encodeWithSignature(
+                depositSignature,
+                IETHV2,
+                ETH_AMOUNT,
+                0,
+                0
+            );
+        }
+
+        IDSAV2(TREASURY).cast(targets, encodedSpells, address(this));
     }
 
     /**

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -495,7 +495,7 @@ contract PayloadIGP95 is PayloadIGPMain {
             }
             {
                 IFluidDex(PAXG_XAUT_DEX).updateMaxSupplyShares(
-                    280 * 1e18 // $1.8M
+                    310 * 1e18 // $2M
                 );
             }
         }
@@ -758,7 +758,9 @@ contract PayloadIGP95 is PayloadIGPMain {
 
         // Spell 1: Deposit stETH into Lite
         {
-            uint256 STETH_AMOUNT = IERC20(stETH_ADDRESS).balanceOf(address(TREASURY));
+            uint256 STETH_AMOUNT = IERC20(stETH_ADDRESS).balanceOf(
+                address(TREASURY)
+            );
             targets[0] = "BASIC-D-V2";
             encodedSpells[0] = abi.encodeWithSignature(
                 depositSignature,
@@ -842,15 +844,15 @@ contract PayloadIGP95 is PayloadIGPMain {
      */
 
     // Token Prices Constants
-    uint256 public constant ETH_USD_PRICE = 1_750 * 1e2;
-    uint256 public constant wstETH_USD_PRICE = 2_300 * 1e2;
-    uint256 public constant weETH_USD_PRICE = 2_000 * 1e2;
-    uint256 public constant rsETH_USD_PRICE = 1_975 * 1e2;
-    uint256 public constant weETHs_USD_PRICE = 1_930 * 1e2;
-    uint256 public constant mETH_USD_PRICE = 2_000 * 1e2;
-    uint256 public constant ezETH_USD_PRICE = 1_975 * 1e2;
+    uint256 public constant ETH_USD_PRICE = 2_400 * 1e2;
+    uint256 public constant wstETH_USD_PRICE = 2_950 * 1e2;
+    uint256 public constant weETH_USD_PRICE = 2_600 * 1e2;
+    uint256 public constant rsETH_USD_PRICE = 2_550 * 1e2;
+    uint256 public constant weETHs_USD_PRICE = 2_500 * 1e2;
+    uint256 public constant mETH_USD_PRICE = 2_590 * 1e2;
+    uint256 public constant ezETH_USD_PRICE = 2_550 * 1e2;
 
-    uint256 public constant BTC_USD_PRICE = 94_500 * 1e2;
+    uint256 public constant BTC_USD_PRICE = 103_500 * 1e2;
 
     uint256 public constant STABLE_USD_PRICE = 1 * 1e2;
     uint256 public constant sUSDe_USD_PRICE = 1.15 * 1e2;
@@ -860,9 +862,8 @@ contract PayloadIGP95 is PayloadIGPMain {
 
     uint256 public constant RLP_USD_PRICE = 1.16 * 1e2;
     uint256 public constant wstUSR_USD_PRICE = 1.07 * 1e2;
-
-    uint256 public constant XAUT_USD_PRICE = 3_400 * 1e2;
-    uint256 public constant PAXG_USD_PRICE = 3_400 * 1e2;
+    uint256 public constant XAUT_USD_PRICE = 3_350 * 1e2;
+    uint256 public constant PAXG_USD_PRICE = 3_350 * 1e2;
 
     function getRawAmount(
         address token,

--- a/contracts/payloads/IGP95/PayloadIGP95.sol
+++ b/contracts/payloads/IGP95/PayloadIGP95.sol
@@ -811,7 +811,7 @@ contract PayloadIGP95 is PayloadIGPMain {
                     memory config_ = new IFluidDex.UserBorrowConfig[](1);
                 config_[0] = IFluidAdminDex.UserBorrowConfig({
                     user: WSTETH_ETH__WSTETH_ETH_VAULT,
-                    expandPercent: 35 * 1e2, // 35%
+                    expandPercent: 30 * 1e2, // 30%
                     expandDuration: 6 hours, // 6 hours
                     baseDebtCeiling: 3_000 * 1e18, // 3k shares
                     maxDebtCeiling: 12_000 * 1e18 // 12k shares

--- a/contracts/payloads/common/constants.sol
+++ b/contracts/payloads/common/constants.sol
@@ -87,6 +87,8 @@ contract PayloadIGPConstants {
         0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;  
     address internal constant wstETH_ADDRESS =
         0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
+    address internal constant stETH_ADDRESS =
+        0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
     address internal constant weETH_ADDRESS =
         0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee;
     address internal constant rsETH_ADDRESS =


### PR DESCRIPTION
        // Action 1: Set dust limits for sUSDe-GHO and USDC-GHO DEXes
        action1();

        // Action 2: Set dust limits for sUSDe-GHO/USDC-GHO T4 vault
        action2();

        // Action 3: Reduce allowance of fUSDC and fUSDT
        action3();

        // Action 4: Remove Borrow Rewards handlers as Vault Auth
        action4();

        // Action 5: Remove Team Multisig as Auth on Unlaunched Vaults
        action5();

        // Action 6: Pause Limits for Unlaunched USDe Collateral Vaults
        action6();

        // Action 7: Pause Limits for Bugged DEXes
        action7();

        // Action 8: Set Launch Limits for RLP-USDC DEX
        action8();

        // Action 9: Set Launch Limits for Gold Vaults and DEX
        action9();

        // Action 10: Update Borrow Limits for sUSDe/USDC
        action10();
        
        // Action 11: Update Range Percentages for USD0-USDC DEX
        action11();

        // Action 12: Deposit ETH from Treasury to Lite
        action12();

        // Action 13: Update limits for wstETH-ETH, weETH-ETH DEXes and vaults
        action13();