### PR TITLE
ci: fix shell expression injection in governance-simulation workflow

### DIFF
--- a/.github/workflows/governance-simulation.yml
+++ b/.github/workflows/governance-simulation.yml
@@ -27,10 +27,10 @@ jobs:
 
       - name: Detect IGP from PR title or branch
         id: detect
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ github.head_ref }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          PR_BRANCH="${{ github.head_ref }}"
-
           echo "PR Title: $PR_TITLE"
           echo "PR Branch: $PR_BRANCH"
 


### PR DESCRIPTION
The detect step interpolated `github.event.pull_request.title` / `github.head_ref`
directly into a shell script (expression injection). Passing them via `env:` neutralizes it.