### PR TITLE
IGP133

### DIFF
--- a/contracts/payloads/IGP133/PayloadIGP133.sol
+++ b/contracts/payloads/IGP133/PayloadIGP133.sol
@@ -5,29 +5,139 @@ pragma experimental ABIEncoderV2;
 import {
     AdminModuleStructs as FluidLiquidityAdminStructs
 } from "../common/interfaces/IFluidLiquidity.sol";
+import {IInfiniteProxy} from "../common/interfaces/IInfiniteProxy.sol";
+import {
+    IFluidLiquidityRollback
+} from "../common/interfaces/IFluidLiquidityRollback.sol";
 import {PayloadIGPPriceHelpers} from "../common/pricehelpers.sol";
 
-/// @notice IGP133: Risk-tightening of borrow limits across 66 less-trusted
-///         Ethereum vaults. Lowers base/max debt ceilings, reduces borrow
-///         expansion to 25% (10% for the largest pools) and shortens the
-///         expansion window from 6h to 3h on every affected vault.
+/// @notice IGP133: Liquidity Layer UserModule and AdminModule upgrades with
+///         rollback registration and pause / rates / range auth rotations,
+///         then risk-tightening of borrow limits across 66 less-trusted
+///         Ethereum vaults.
 contract PayloadIGP133 is PayloadIGPPriceHelpers {
     uint256 public constant PROPOSAL_ID = 133;
+
+    address public constant OLD_USER_MODULE =
+        0x4bDC8816F2f56914B66EbF3786D78872D3a73Ab7;
+    address public constant OLD_ADMIN_MODULE =
+        0xea78faBC13D603895FE9efe8BB4A4F2c56e5698E;
+    address public constant OLD_LIQUIDITY_PAUSE_AUTH =
+        0xE9332F2d45e3216B7634cA4C7ab88945CD84ab76;
+    address public constant OLD_DEX_PAUSE_AUTH =
+        0x735BA3772c2cCC0b92Ff6993bd71da88236C1495;
+    address public constant OLD_RATES_AUTH =
+        0x1e6B029284dc2779F8FfBD83a3a5aA00EdCE6ba4;
+    address public constant OLD_RANGE_AUTH =
+        0x827089c01E9f761ff1A6D7041a9388bDdae74cc4;
+
+    address public newUserModuleAddress = address(0);
+    address public newAdminModuleAddress = address(0);
+    address public liquidityPauseAuth = address(0);
+    address public dexPauseAuth = address(0);
+    address public newRatesAuth = address(0);
+    address public newRangeAuth = address(0);
+
+    bool public newUserModuleAddressLocked;
+    bool public newAdminModuleAddressLocked;
+    bool public pauseAuthsLocked;
+    bool public ratesAuthsLocked;
+    bool public rangeAuthsLocked;
+
+    function lockNewUserModuleAddress() external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        newUserModuleAddressLocked = true;
+    }
+
+    function lockNewAdminModuleAddress() external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        newAdminModuleAddressLocked = true;
+    }
+
+    function lockPauseAuths() external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        pauseAuthsLocked = true;
+    }
+
+    function lockRatesAuths() external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        ratesAuthsLocked = true;
+    }
+
+    function lockRangeAuths() external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        rangeAuthsLocked = true;
+    }
+
+    function setNewUserModuleAddress(address newUserModuleAddress_) external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        require(!newUserModuleAddressLocked, "locked");
+        newUserModuleAddress = newUserModuleAddress_;
+    }
+
+    function setNewAdminModuleAddress(address newAdminModuleAddress_) external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        require(!newAdminModuleAddressLocked, "locked");
+        newAdminModuleAddress = newAdminModuleAddress_;
+    }
+
+    function setPauseAuths(
+        address liquidityPauseAuth_,
+        address dexPauseAuth_
+    ) external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        require(!pauseAuthsLocked, "locked");
+        liquidityPauseAuth = liquidityPauseAuth_;
+        dexPauseAuth = dexPauseAuth_;
+    }
+
+    function setNewRatesAuth(address newRatesAuth_) external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        require(!ratesAuthsLocked, "locked");
+        newRatesAuth = newRatesAuth_;
+    }
+
+    function setNewRangeAuth(address newRangeAuth_) external {
+        require(msg.sender == TEAM_MULTISIG, "not-team-multisig");
+        require(!rangeAuthsLocked, "locked");
+        newRangeAuth = newRangeAuth_;
+    }
 
     function execute() public virtual override {
         super.execute();
 
-        // Action 1: Tighten Liquidity Layer borrow limits on 54 vaults
+        // Action 1: Register UserModule LL upgrade on RollbackModule
         action1();
 
-        // Action 2: Tighten smart-debt limits on the USDC-USDT DEX (id 2)
+        // Action 2: Upgrade UserModule LL on InfiniteProxy
         action2();
 
-        // Action 3: Tighten smart-debt limits on the USDC-USDT DEX (id 34)
+        // Action 3: Register AdminModule LL upgrade on RollbackModule
         action3();
 
-        // Action 4: Tighten smart-debt limits on the GHO-USDC DEX (id 4)
+        // Action 4: Upgrade AdminModule LL on InfiniteProxy
         action4();
+
+        // Action 5: Set new pause auth contracts
+        action5();
+
+        // Action 6: Update Rates Auth on Liquidity Layer
+        action6();
+
+        // Action 7: Update Ranges Auth on DexFactory
+        action7();
+
+        // Action 8: Tighten Liquidity Layer borrow limits on 54 vaults
+        action8();
+
+        // Action 9: Tighten smart-debt limits on the USDC-USDT DEX (id 2)
+        action9();
+
+        // Action 10: Tighten smart-debt limits on the USDC-USDT DEX (id 34)
+        action10();
+
+        // Action 11: Tighten smart-debt limits on the GHO-USDC DEX (id 4)
+        action11();
     }
 
     function verifyProposal() public view override {}
@@ -42,8 +152,114 @@ contract PayloadIGP133 is PayloadIGPPriceHelpers {
      * |__________________________________
      */
 
-    /// @notice Action 1: Tighten Liquidity Layer borrow limits (expand window 6h -> 3h)
+    /// @notice Action 1: Register UserModule LL upgrade on RollbackModule
     function action1() internal isActionSkippable(1) {
+        address newUserModule_ = PayloadIGP133(ADDRESS_THIS).newUserModuleAddress();
+        require(newUserModule_ != address(0), "new-user-module-not-set");
+
+        IFluidLiquidityRollback(address(LIQUIDITY))
+            .registerRollbackImplementation(OLD_USER_MODULE, newUserModule_);
+    }
+
+    /// @notice Action 2: Upgrade UserModule LL on InfiniteProxy
+    function action2() internal isActionSkippable(2) {
+        address newUserModule_ = PayloadIGP133(ADDRESS_THIS).newUserModuleAddress();
+        require(newUserModule_ != address(0), "new-user-module-not-set");
+
+        bytes4[] memory sigs_ = IInfiniteProxy(address(LIQUIDITY))
+            .getImplementationSigs(OLD_USER_MODULE);
+
+        IInfiniteProxy(address(LIQUIDITY)).removeImplementation(OLD_USER_MODULE);
+
+        IInfiniteProxy(address(LIQUIDITY)).addImplementation(
+            newUserModule_,
+            sigs_
+        );
+    }
+
+    /// @notice Action 3: Register AdminModule LL upgrade on RollbackModule
+    function action3() internal isActionSkippable(3) {
+        address newAdminModule_ = PayloadIGP133(ADDRESS_THIS).newAdminModuleAddress();
+        require(newAdminModule_ != address(0), "new-admin-module-not-set");
+
+        IFluidLiquidityRollback(address(LIQUIDITY))
+            .registerRollbackImplementation(OLD_ADMIN_MODULE, newAdminModule_);
+    }
+
+    /// @notice Action 4: Upgrade AdminModule LL on InfiniteProxy
+    function action4() internal isActionSkippable(4) {
+        address newAdminModule_ = PayloadIGP133(ADDRESS_THIS).newAdminModuleAddress();
+        require(newAdminModule_ != address(0), "new-admin-module-not-set");
+
+        bytes4[] memory sigs_ = IInfiniteProxy(address(LIQUIDITY))
+            .getImplementationSigs(OLD_ADMIN_MODULE);
+
+        IInfiniteProxy(address(LIQUIDITY)).removeImplementation(OLD_ADMIN_MODULE);
+
+        IInfiniteProxy(address(LIQUIDITY)).addImplementation(
+            newAdminModule_,
+            sigs_
+        );
+    }
+
+    /// @notice Action 5: Set new pause auth contracts
+    function action5() internal isActionSkippable(5) {
+        address liquidityPauseAuth_ = PayloadIGP133(ADDRESS_THIS).liquidityPauseAuth();
+        address dexPauseAuth_ = PayloadIGP133(ADDRESS_THIS).dexPauseAuth();
+        require(liquidityPauseAuth_ != address(0), "ll-pause-auth-not-set");
+        require(dexPauseAuth_ != address(0), "dex-pause-auth-not-set");
+
+        FluidLiquidityAdminStructs.AddressBool[]
+            memory guardiansStatus_ = new FluidLiquidityAdminStructs.AddressBool[](
+                2
+            );
+        guardiansStatus_[0] = FluidLiquidityAdminStructs.AddressBool({
+            addr: OLD_LIQUIDITY_PAUSE_AUTH,
+            value: false
+        });
+        guardiansStatus_[1] = FluidLiquidityAdminStructs.AddressBool({
+            addr: liquidityPauseAuth_,
+            value: true
+        });
+        LIQUIDITY.updateGuardians(guardiansStatus_);
+
+        DEX_FACTORY.setGlobalAuth(OLD_DEX_PAUSE_AUTH, false);
+        DEX_FACTORY.setGlobalAuth(dexPauseAuth_, true);
+    }
+
+    /// @notice Action 6: Update Rates Auth on Liquidity Layer
+    function action6() internal isActionSkippable(6) {
+        address newRatesAuth_ = PayloadIGP133(ADDRESS_THIS).newRatesAuth();
+        require(newRatesAuth_ != address(0), "new-rates-auth-not-set");
+
+        FluidLiquidityAdminStructs.AddressBool[]
+            memory authsStatus_ = new FluidLiquidityAdminStructs.AddressBool[](
+                2
+            );
+
+        authsStatus_[0] = FluidLiquidityAdminStructs.AddressBool({
+            addr: OLD_RATES_AUTH,
+            value: false
+        });
+        authsStatus_[1] = FluidLiquidityAdminStructs.AddressBool({
+            addr: newRatesAuth_,
+            value: true
+        });
+
+        LIQUIDITY.updateAuths(authsStatus_);
+    }
+
+    /// @notice Action 7: Update Ranges Auth on DexFactory
+    function action7() internal isActionSkippable(7) {
+        address newRangeAuth_ = PayloadIGP133(ADDRESS_THIS).newRangeAuth();
+        require(newRangeAuth_ != address(0), "new-range-auth-not-set");
+
+        DEX_FACTORY.setGlobalAuth(OLD_RANGE_AUTH, false);
+        DEX_FACTORY.setGlobalAuth(newRangeAuth_, true);
+    }
+
+    /// @notice Action 8: Tighten Liquidity Layer borrow limits (expand window 6h -> 3h)
+    function action8() internal isActionSkippable(8) {
         FluidLiquidityAdminStructs.UserBorrowConfig[]
             memory configs_ = new FluidLiquidityAdminStructs.UserBorrowConfig[](
                 54
@@ -485,8 +701,8 @@ contract PayloadIGP133 is PayloadIGPPriceHelpers {
         LIQUIDITY.updateUserBorrowConfigs(configs_);
     }
 
-    /// @notice Action 2: Tighten smart-debt limits on the USDC-USDT DEX (id 2) (expand window 6h -> 3h, share $2.204907979983792)
-    function action2() internal isActionSkippable(2) {
+    /// @notice Action 9: Tighten smart-debt limits on the USDC-USDT DEX (id 2) (expand window 6h -> 3h, share $2.204907979983792)
+    function action9() internal isActionSkippable(9) {
         address dex_ = getDexAddress(2);
 
         // Vault 47 (weETH / USDC-USDT): $2.5M base / $25M max
@@ -562,8 +778,8 @@ contract PayloadIGP133 is PayloadIGPPriceHelpers {
         );
     }
 
-    /// @notice Action 3: Tighten smart-debt limits on the USDC-USDT DEX (id 34) (expand window 6h -> 3h, share $2.102974865610295)
-    function action3() internal isActionSkippable(3) {
+    /// @notice Action 10: Tighten smart-debt limits on the USDC-USDT DEX (id 34) (expand window 6h -> 3h, share $2.102974865610295)
+    function action10() internal isActionSkippable(10) {
         address dex_ = getDexAddress(34);
 
         // Vault 126 (sUSDe-USDT / USDC-USDT): $2.5M base / $50M max
@@ -603,8 +819,8 @@ contract PayloadIGP133 is PayloadIGPPriceHelpers {
         );
     }
 
-    /// @notice Action 4: Tighten smart-debt limits on the GHO-USDC DEX (id 4) (expand window 6h -> 3h, share $2.2159112801948067)
-    function action4() internal isActionSkippable(4) {
+    /// @notice Action 11: Tighten smart-debt limits on the GHO-USDC DEX (id 4) (expand window 6h -> 3h, share $2.2159112801948067)
+    function action11() internal isActionSkippable(11) {
         address dex_ = getDexAddress(4);
 
         // Vault 61 (GHO-USDC / GHO-USDC): $2.5M base / $25M max

--- a/contracts/payloads/IGP133/PayloadIGP133.sol
+++ b/contracts/payloads/IGP133/PayloadIGP133.sol
@@ -1,0 +1,688 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.21;
+pragma experimental ABIEncoderV2;
+
+import {
+    AdminModuleStructs as FluidLiquidityAdminStructs
+} from "../common/interfaces/IFluidLiquidity.sol";
+import {PayloadIGPPriceHelpers} from "../common/pricehelpers.sol";
+
+/// @notice IGP133: Risk-tightening of borrow limits across 66 less-trusted
+///         Ethereum vaults. Lowers base/max debt ceilings, reduces borrow
+///         expansion to 25% (10% for the largest pools) and shortens the
+///         expansion window from 6h to 3h on every affected vault.
+contract PayloadIGP133 is PayloadIGPPriceHelpers {
+    uint256 public constant PROPOSAL_ID = 133;
+
+    function execute() public virtual override {
+        super.execute();
+
+        // Action 1: Tighten Liquidity Layer borrow limits on 54 vaults
+        action1();
+
+        // Action 2: Tighten smart-debt limits on the USDC-USDT DEX (id 2)
+        action2();
+
+        // Action 3: Tighten smart-debt limits on the USDC-USDT DEX (id 34)
+        action3();
+
+        // Action 4: Tighten smart-debt limits on the GHO-USDC DEX (id 4)
+        action4();
+    }
+
+    function verifyProposal() public view override {}
+
+    function _PROPOSAL_ID() internal view override returns (uint256) {
+        return PROPOSAL_ID;
+    }
+
+    /**
+     * |
+     * |     Proposal Payload Actions      |
+     * |__________________________________
+     */
+
+    /// @notice Action 1: Tighten Liquidity Layer borrow limits (expand window 6h -> 3h)
+    function action1() internal isActionSkippable(1) {
+        FluidLiquidityAdminStructs.UserBorrowConfig[]
+            memory configs_ = new FluidLiquidityAdminStructs.UserBorrowConfig[](
+                54
+            );
+
+        // Vault 16 (weETH / wstETH) - borrow wstETH @ $2620.73
+        configs_[0] = _borrowConfig(
+            16,
+            wstETH_ADDRESS,
+            25 * 1e2, // 25%
+            953_932_682_878_434_634_625, // $2.5M base -> 953.9327 wstETH
+            9_539_326_828_784_346_346_247 // $25M max -> 9539.3268 wstETH
+        );
+        // Vault 18 (sUSDe / USDT) - borrow USDT @ $0.999409
+        configs_[1] = _borrowConfig(
+            18,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 17 (sUSDe / USDC) - borrow USDC @ $0.99979
+        configs_[2] = _borrowConfig(
+            17,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            25_005_251_102_732 // $25M max -> 25005251.1027 USDC
+        );
+        // Vault 19 (weETH / USDC) - borrow USDC @ $0.99979
+        configs_[3] = _borrowConfig(
+            19,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            25_005_251_102_732 // $25M max -> 25005251.1027 USDC
+        );
+        // Vault 20 (weETH / USDT) - borrow USDT @ $0.999409
+        configs_[4] = _borrowConfig(
+            20,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 26 (weETH / WBTC) - borrow WBTC @ $76897
+        configs_[5] = _borrowConfig(
+            26,
+            WBTC_ADDRESS,
+            25 * 1e2, // 25%
+            130_044_085, // $100K base -> 1.3004 WBTC
+            1_300_440_849 // $1M max -> 13.0044 WBTC
+        );
+        // Vault 27 (weETHs / wstETH) - borrow wstETH @ $2620.73
+        configs_[6] = _borrowConfig(
+            27,
+            wstETH_ADDRESS,
+            25 * 1e2, // 25%
+            381_573_073_151_373_853_850, // $1M base -> 381.5731 wstETH
+            1_907_865_365_756_869_269_249 // $5M max -> 1907.8654 wstETH
+        );
+        // Vault 32 (weETH / cbBTC) - borrow cbBTC @ $77100
+        configs_[7] = _borrowConfig(
+            32,
+            cbBTC_ADDRESS,
+            25 * 1e2, // 25%
+            129_701_686, // $100K base -> 1.2970 cbBTC
+            1_297_016_861 // $1M max -> 12.9702 cbBTC
+        );
+        // Vault 56 (sUSDe / GHO) - borrow GHO @ $0.999374
+        configs_[8] = _borrowConfig(
+            56,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_565_980_303_670_097_481_023, // $2.5M base -> 2501565.9803 GHO
+            25_015_659_803_036_700_974_810_231 // $25M max -> 25015659.8030 GHO
+        );
+        // Vault 57 (weETH / GHO) - borrow GHO @ $0.999374
+        configs_[9] = _borrowConfig(
+            57,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_565_980_303_670_097_481_023, // $2.5M base -> 2501565.9803 GHO
+            25_015_659_803_036_700_974_810_231 // $25M max -> 25015659.8030 GHO
+        );
+        // Vault 74 (weETH-ETH / wstETH) - borrow wstETH @ $2620.73
+        configs_[10] = _borrowConfig(
+            74,
+            wstETH_ADDRESS,
+            10 * 1e2, // 10%
+            953_932_682_878_434_634_625, // $2.5M base -> 953.9327 wstETH
+            19_078_653_657_568_692_692_494 // $50M max -> 19078.6537 wstETH
+        );
+        // Vault 80 (weETHs-ETH / wstETH) - borrow wstETH @ $2620.73
+        configs_[11] = _borrowConfig(
+            80,
+            wstETH_ADDRESS,
+            25 * 1e2, // 25%
+            381_573_073_151_373_853_850, // $1M base -> 381.5731 wstETH
+            953_932_682_878_434_634_625 // $2.5M max -> 953.9327 wstETH
+        );
+        // Vault 92 (sUSDe-USDT / USDT) - borrow USDT @ $0.999409
+        configs_[12] = _borrowConfig(
+            92,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 93 (USDe-USDT / USDT) - borrow USDT @ $0.999409
+        configs_[13] = _borrowConfig(
+            93,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 94 (eBTC / WBTC) - borrow WBTC @ $76897
+        configs_[14] = _borrowConfig(
+            94,
+            WBTC_ADDRESS,
+            25 * 1e2, // 25%
+            130_044_085, // $100K base -> 1.3004 WBTC
+            1_300_440_849 // $1M max -> 13.0044 WBTC
+        );
+        // Vault 96 (eBTC-cbBTC / WBTC) - borrow WBTC @ $76897
+        configs_[15] = _borrowConfig(
+            96,
+            WBTC_ADDRESS,
+            25 * 1e2, // 25%
+            130_044_085, // $100K base -> 1.3004 WBTC
+            1_300_440_849 // $1M max -> 13.0044 WBTC
+        );
+        // Vault 97 (LBTC-cbBTC / WBTC) - borrow WBTC @ $76897
+        configs_[16] = _borrowConfig(
+            97,
+            WBTC_ADDRESS,
+            25 * 1e2, // 25%
+            3_251_102_124, // $2.5M base -> 32.5110 WBTC
+            32_511_021_236 // $25M max -> 325.1102 WBTC
+        );
+        // Vault 103 (ezETH / wstETH) - borrow wstETH @ $2620.73
+        configs_[17] = _borrowConfig(
+            103,
+            wstETH_ADDRESS,
+            25 * 1e2, // 25%
+            38_157_307_315_137_385_385, // $100K base -> 38.1573 wstETH
+            381_573_073_151_373_853_850 // $1M max -> 381.5731 wstETH
+        );
+        // Vault 104 (ezETH-ETH / wstETH) - borrow wstETH @ $2620.73
+        configs_[18] = _borrowConfig(
+            104,
+            wstETH_ADDRESS,
+            25 * 1e2, // 25%
+            953_932_682_878_434_634_625, // $2.5M base -> 953.9327 wstETH
+            9_539_326_828_784_346_346_247 // $25M max -> 9539.3268 wstETH
+        );
+        // Vault 107 (LBTC / USDC) - borrow USDC @ $0.99979
+        configs_[19] = _borrowConfig(
+            107,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            25_005_251_102_732 // $25M max -> 25005251.1027 USDC
+        );
+        // Vault 108 (LBTC / USDT) - borrow USDT @ $0.999409
+        configs_[20] = _borrowConfig(
+            108,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_491_472_460_224, // $2.49M base -> 2491472.4602 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 109 (LBTC / GHO) - borrow GHO @ $0.999374
+        configs_[21] = _borrowConfig(
+            109,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_565_980_303_670_097_481_023, // $2.5M base -> 2501565.9803 GHO
+            25_015_659_803_036_700_974_810_231 // $25M max -> 25015659.8030 GHO
+        );
+        // Vault 114 (LBTC-cbBTC / cbBTC) - borrow cbBTC @ $77100
+        configs_[22] = _borrowConfig(
+            114,
+            cbBTC_ADDRESS,
+            25 * 1e2, // 25%
+            3_242_542_153, // $2.5M base -> 32.4254 cbBTC
+            32_425_421_530 // $25M max -> 324.2542 cbBTC
+        );
+        // Vault 115 (WBTC-LBTC / WBTC) - borrow WBTC @ $76897
+        configs_[23] = _borrowConfig(
+            115,
+            WBTC_ADDRESS,
+            25 * 1e2, // 25%
+            3_251_102_124, // $2.5M base -> 32.5110 WBTC
+            32_511_021_236 // $25M max -> 325.1102 WBTC
+        );
+        // Vault 116 (XAUt / USDC) - borrow USDC @ $0.99979
+        configs_[24] = _borrowConfig(
+            116,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            25_005_251_102_732 // $25M max -> 25005251.1027 USDC
+        );
+        // Vault 117 (XAUt / USDT) - borrow USDT @ $0.999409
+        configs_[25] = _borrowConfig(
+            117,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 118 (XAUt / GHO) - borrow GHO @ $0.999374
+        configs_[26] = _borrowConfig(
+            118,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_626_392_121_468_038_992_409, // $1M base -> 1000626.3921 GHO
+            10_006_263_921_214_680_389_924_092 // $10M max -> 10006263.9212 GHO
+        );
+        // Vault 119 (PAXG / USDC) - borrow USDC @ $0.99979
+        configs_[27] = _borrowConfig(
+            119,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            25_005_251_102_732 // $25M max -> 25005251.1027 USDC
+        );
+        // Vault 120 (PAXG / USDT) - borrow USDT @ $0.999409
+        configs_[28] = _borrowConfig(
+            120,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 121 (PAXG / GHO) - borrow GHO @ $0.999374
+        configs_[29] = _borrowConfig(
+            121,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_626_392_121_468_038_992_409, // $1M base -> 1000626.3921 GHO
+            10_006_263_921_214_680_389_924_092 // $10M max -> 10006263.9212 GHO
+        );
+        // Vault 122 (PAXG-XAUt / USDC) - borrow USDC @ $0.99979
+        configs_[30] = _borrowConfig(
+            122,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_210_044_109, // $1M base -> 1000210.0441 USDC
+            2_500_525_110_273 // $2.5M max -> 2500525.1103 USDC
+        );
+        // Vault 123 (PAXG-XAUt / USDT) - borrow USDT @ $0.999409
+        configs_[31] = _borrowConfig(
+            123,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 124 (PAXG-XAUt / GHO) - borrow GHO @ $0.999374
+        configs_[32] = _borrowConfig(
+            124,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_626_392_121_468_038_992_409, // $1M base -> 1000626.3921 GHO
+            10_006_263_921_214_680_389_924_092 // $10M max -> 10006263.9212 GHO
+        );
+        // Vault 130 (weETH / USDtb) - borrow USDtb @ $0.999168
+        configs_[33] = _borrowConfig(
+            130,
+            USDTb_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_832_692_800_409_941_070_971, // $1M base -> 1000832.6928 USDtb
+            2_502_081_732_001_024_852_677_428 // $2.5M max -> 2502081.7320 USDtb
+        );
+        // Vault 137 (USDe-USDtb / USDT) - borrow USDT @ $0.999409
+        configs_[34] = _borrowConfig(
+            137,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_591_349_488, // $1M base -> 1000591.3495 USDT
+            10_005_913_494_875 // $10M max -> 10005913.4949 USDT
+        );
+        // Vault 138 (USDe-USDtb / USDC) - borrow USDC @ $0.99979
+        configs_[35] = _borrowConfig(
+            138,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_210_044_109, // $1M base -> 1000210.0441 USDC
+            10_002_100_441_093 // $10M max -> 10002100.4411 USDC
+        );
+        // Vault 140 (USDe-USDtb / GHO) - borrow GHO @ $0.999374
+        configs_[36] = _borrowConfig(
+            140,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_626_392_121_468_038_992_409, // $1M base -> 1000626.3921 GHO
+            10_006_263_921_214_680_389_924_092 // $10M max -> 10006263.9212 GHO
+        );
+        // Vault 141 (GHO-USDe / GHO) - borrow GHO @ $0.999374
+        configs_[37] = _borrowConfig(
+            141,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_626_392_121_468_038_992_409, // $1M base -> 1000626.3921 GHO
+            10_006_263_921_214_680_389_924_092 // $10M max -> 10006263.9212 GHO
+        );
+        // Vault 145 (syrupUSDC-USDC / USDC) - borrow USDC @ $0.99979
+        configs_[38] = _borrowConfig(
+            145,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            25_005_251_102_732 // $25M max -> 25005251.1027 USDC
+        );
+        // Vault 146 (syrupUSDC / USDC) - borrow USDC @ $0.99979
+        configs_[39] = _borrowConfig(
+            146,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            25_005_251_102_732 // $25M max -> 25005251.1027 USDC
+        );
+        // Vault 147 (syrupUSDC / USDT) - borrow USDT @ $0.999409
+        configs_[40] = _borrowConfig(
+            147,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_591_349_488, // $1M base -> 1000591.3495 USDT
+            2_501_478_373_719 // $2.5M max -> 2501478.3737 USDT
+        );
+        // Vault 148 (syrupUSDC / GHO) - borrow GHO @ $0.999374
+        configs_[41] = _borrowConfig(
+            148,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_626_392_121_468_038_992_409, // $1M base -> 1000626.3921 GHO
+            2_501_565_980_303_670_097_481_023 // $2.5M max -> 2501565.9803 GHO
+        );
+        // Vault 149 (syrupUSDT-USDT / USDT) - borrow USDT @ $0.999409
+        configs_[42] = _borrowConfig(
+            149,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 150 (syrupUSDT / USDC) - borrow USDC @ $0.99979
+        configs_[43] = _borrowConfig(
+            150,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            1_000_210_044_109, // $1M base -> 1000210.0441 USDC
+            2_500_525_110_273 // $2.5M max -> 2500525.1103 USDC
+        );
+        // Vault 151 (syrupUSDT / USDT) - borrow USDT @ $0.999409
+        configs_[44] = _borrowConfig(
+            151,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            25_014_783_737_189 // $25M max -> 25014783.7372 USDT
+        );
+        // Vault 152 (syrupUSDT / GHO) - borrow GHO @ $0.999374
+        configs_[45] = _borrowConfig(
+            152,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            100_062_639_212_146_803_899_241, // $100K base -> 100062.6392 GHO
+            1_000_626_392_121_468_038_992_409 // $1M max -> 1000626.3921 GHO
+        );
+        // Vault 153 (osETH / USDC) - borrow USDC @ $0.99979
+        configs_[46] = _borrowConfig(
+            153,
+            USDC_ADDRESS,
+            25 * 1e2, // 25%
+            100_021_004_411, // $100K base -> 100021.0044 USDC
+            1_000_210_044_109 // $1M max -> 1000210.0441 USDC
+        );
+        // Vault 154 (osETH / USDT) - borrow USDT @ $0.999409
+        configs_[47] = _borrowConfig(
+            154,
+            USDT_ADDRESS,
+            25 * 1e2, // 25%
+            100_059_134_949, // $100K base -> 100059.1349 USDT
+            1_000_591_349_488 // $1M max -> 1000591.3495 USDT
+        );
+        // Vault 155 (osETH / GHO) - borrow GHO @ $0.999374
+        configs_[48] = _borrowConfig(
+            155,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            100_062_639_212_146_803_899_241, // $100K base -> 100062.6392 GHO
+            1_000_626_392_121_468_038_992_409 // $1M max -> 1000626.3921 GHO
+        );
+        // Vault 159 (ETH-osETH / wstETH) - borrow wstETH @ $2620.73
+        configs_[49] = _borrowConfig(
+            159,
+            wstETH_ADDRESS,
+            10 * 1e2, // 10%
+            953_932_682_878_434_634_625, // $2.5M base -> 953.9327 wstETH
+            9_539_326_828_784_346_346_247 // $25M max -> 9539.3268 wstETH
+        );
+        // Vault 160 (reUSD / USDC) - borrow USDC @ $0.99979
+        configs_[50] = _borrowConfig(
+            160,
+            USDC_ADDRESS,
+            10 * 1e2, // 10%
+            2_500_525_110_273, // $2.5M base -> 2500525.1103 USDC
+            20_004_200_882_185 // $20M max -> 20004200.8822 USDC
+        );
+        // Vault 161 (reUSD / USDT) - borrow USDT @ $0.999409
+        configs_[51] = _borrowConfig(
+            161,
+            USDT_ADDRESS,
+            10 * 1e2, // 10%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            20_011_826_989_751 // $20M max -> 20011826.9898 USDT
+        );
+        // Vault 162 (reUSD / GHO) - borrow GHO @ $0.999374
+        configs_[52] = _borrowConfig(
+            162,
+            GHO_ADDRESS,
+            25 * 1e2, // 25%
+            2_501_565_980_303_670_097_481_023, // $2.5M base -> 2501565.9803 GHO
+            20_012_527_842_429_360_779_848_185 // $20M max -> 20012527.8424 GHO
+        );
+        // Vault 164 (reUSD-USDT / USDT) - borrow USDT @ $0.999409
+        configs_[53] = _borrowConfig(
+            164,
+            USDT_ADDRESS,
+            10 * 1e2, // 10%
+            2_501_478_373_719, // $2.5M base -> 2501478.3737 USDT
+            20_011_826_989_751 // $20M max -> 20011826.9898 USDT
+        );
+
+        LIQUIDITY.updateUserBorrowConfigs(configs_);
+    }
+
+    /// @notice Action 2: Tighten smart-debt limits on the USDC-USDT DEX (id 2) (expand window 6h -> 3h, share $2.204907979983792)
+    function action2() internal isActionSkippable(2) {
+        address dex_ = getDexAddress(2);
+
+        // Vault 47 (weETH / USDC-USDT): $2.5M base / $25M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(47),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_133_834_165_731_658_871_386_632, // $2.5M in shares
+                maxBorrowLimit: 11_338_341_657_316_588_713_866_321 // $25M in shares
+            })
+        );
+
+        // Vault 50 (sUSDe / USDC-USDT): $2.5M base / $25M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(50),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_133_834_165_731_658_871_386_632, // $2.5M in shares
+                maxBorrowLimit: 11_338_341_657_316_588_713_866_321 // $25M in shares
+            })
+        );
+
+        // Vault 98 (sUSDe-USDT / USDC-USDT): $2.5M base / $25M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(98),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_133_834_165_731_658_871_386_632, // $2.5M in shares
+                maxBorrowLimit: 11_338_341_657_316_588_713_866_321 // $25M in shares
+            })
+        );
+
+        // Vault 99 (USDe-USDT / USDC-USDT): $2.5M base / $25M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(99),
+                expandPercent: 10 * 1e2, // 10%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_133_834_165_731_658_871_386_632, // $2.5M in shares
+                maxBorrowLimit: 11_338_341_657_316_588_713_866_321 // $25M in shares
+            })
+        );
+
+        // Vault 156 (osETH / USDC-USDT): $100K base / $1M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(156),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 45_353_366_629_266_354_855_465, // $100K in shares
+                maxBorrowLimit: 453_533_666_292_663_548_554_653 // $1M in shares
+            })
+        );
+
+        // Vault 163 (reUSD / USDC-USDT): $2.5M base / $20M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(163),
+                expandPercent: 10 * 1e2, // 10%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_133_834_165_731_658_871_386_632, // $2.5M in shares
+                maxBorrowLimit: 9_070_673_325_853_270_971_093_057 // $20M in shares
+            })
+        );
+    }
+
+    /// @notice Action 3: Tighten smart-debt limits on the USDC-USDT DEX (id 34) (expand window 6h -> 3h, share $2.102974865610295)
+    function action3() internal isActionSkippable(3) {
+        address dex_ = getDexAddress(34);
+
+        // Vault 126 (sUSDe-USDT / USDC-USDT): $2.5M base / $50M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(126),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_188_792_144_348_566_000_699_581, // $2.5M in shares
+                maxBorrowLimit: 23_775_842_886_971_320_013_991_626 // $50M in shares
+            })
+        );
+
+        // Vault 127 (USDe-USDT / USDC-USDT): $2.5M base / $50M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(127),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_188_792_144_348_566_000_699_581, // $2.5M in shares
+                maxBorrowLimit: 23_775_842_886_971_320_013_991_626 // $50M in shares
+            })
+        );
+
+        // Vault 157 (osETH / USDC-USDT): $100K base / $1M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(157),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 47_551_685_773_942_640_027_983, // $100K in shares
+                maxBorrowLimit: 475_516_857_739_426_400_279_833 // $1M in shares
+            })
+        );
+    }
+
+    /// @notice Action 4: Tighten smart-debt limits on the GHO-USDC DEX (id 4) (expand window 6h -> 3h, share $2.2159112801948067)
+    function action4() internal isActionSkippable(4) {
+        address dex_ = getDexAddress(4);
+
+        // Vault 61 (GHO-USDC / GHO-USDC): $2.5M base / $25M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(61),
+                expandPercent: 10 * 1e2, // 10%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 1_128_204_013_556_092_507_093_688, // $2.5M in shares
+                maxBorrowLimit: 11_282_040_135_560_925_070_936_876 // $25M in shares
+            })
+        );
+
+        // Vault 125 (GHO-sUSDe / GHO-USDC): $1M base / $25M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(125),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 451_281_605_422_437_002_837_475, // $1M in shares
+                maxBorrowLimit: 11_282_040_135_560_925_070_936_876 // $25M in shares
+            })
+        );
+
+        // Vault 139 (GHO-USDe / GHO-USDC): $1M base / $10M max
+        setDexBorrowProtocolLimitsInShares(
+            DexBorrowProtocolConfigInShares({
+                dex: dex_,
+                protocol: getVaultAddress(139),
+                expandPercent: 25 * 1e2, // 25%
+                expandDuration: 3 hours,
+                baseBorrowLimit: 451_281_605_422_437_002_837_475, // $1M in shares
+                maxBorrowLimit: 4_512_816_054_224_370_028_374_750 // $10M in shares
+            })
+        );
+    }
+
+    /**
+     * |
+     * |     Payload Actions End Here      |
+     * |__________________________________
+     */
+
+    /// @dev Build a Liquidity Layer borrow config. `baseAmount` / `maxAmount`
+    ///      are denominated in the borrow token's own decimals (already
+    ///      converted from USD using the per-vault override price); they are
+    ///      normalised by the live borrow exchange price via `getRawAmount`.
+    function _borrowConfig(
+        uint256 vaultId_,
+        address token_,
+        uint256 expandPercent_,
+        uint256 baseAmount_,
+        uint256 maxAmount_
+    )
+        internal
+        view
+        returns (FluidLiquidityAdminStructs.UserBorrowConfig memory)
+    {
+        return
+            FluidLiquidityAdminStructs.UserBorrowConfig({
+                user: getVaultAddress(vaultId_),
+                token: token_,
+                mode: 1,
+                expandPercent: expandPercent_,
+                expandDuration: 3 hours,
+                baseDebtCeiling: getRawAmount(token_, baseAmount_, 0, false),
+                maxDebtCeiling: getRawAmount(token_, maxAmount_, 0, false)
+            });
+    }
+
+    // --- Representative override prices (USD * 1e2) -------------------------
+    // The borrow limits above are pre-converted to exact token / share amounts
+    // using the precise per-vault override prices documented inline, so these
+    // getters are only consulted by the inherited `getRawAmount` token dispatch
+    // and do not affect the configured ceilings.
+    function wstETH_USD_PRICE() public pure override returns (uint256) { return 2_620.73 * 1e2; }
+    function BTC_USD_PRICE()    public pure override returns (uint256) { return 76_897 * 1e2; }
+    function STABLE_USD_PRICE() public pure override returns (uint256) { return 1 * 1e2; }
+}

--- a/contracts/payloads/IGP133/description.md
+++ b/contracts/payloads/IGP133/description.md
@@ -1,0 +1,119 @@
+# Risk-Tightening of Borrow Limits Across 66 Ethereum Vaults
+
+## Summary
+
+This proposal lowers borrow-side risk on **66 less-trusted Ethereum vaults** in a single batch. For every affected vault it reduces the base and max debt ceilings, cuts the borrow expansion percent to **25%** (or **10%** on the largest pools), and shortens the borrow expansion window from **6h to 3h**. No supply / withdrawal limits, oracles, auths, or other parameters are touched.
+
+The changes are grouped into four actions: **Action 1** updates 54 vaults that borrow directly at the Liquidity Layer (single batched `updateUserBorrowConfigs`), and **Actions 2–4** update the 12 smart-debt vaults that borrow through a DEX (USDC-USDT id 2, USDC-USDT id 34, and GHO-USDC id 4 respectively).
+
+All new ceilings are pre-converted from their USD targets to exact token / share amounts using the per-vault override prices listed in the tables below, so the configured limits are independent of any rounding in the shared price getters.
+
+## Code Changes
+
+### Action 1: Tighten Liquidity Layer Borrow Limits (54 vaults)
+
+Batched into one `LIQUIDITY.updateUserBorrowConfigs(...)` call. Expansion window for every row goes **6h → 3h**. Base / max columns show **old → new** USD.
+
+| Vault | Market | Type | Debt token | Base (old → new) | Max (old → new) | Expand % | Override price |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 16 | weETH / wstETH | T1 | wstETH | $11.70M → **$2.50M** | $175.51M → **$25M** | 50% → **25%** | $2,620.73 |
+| 18 | sUSDe / USDT | T1 | USDT | $12.89M → **$2.50M** | $64.47M → **$25M** | 50% → **25%** | $0.999409 |
+| 17 | sUSDe / USDC | T1 | USDC | $13.02M → **$2.50M** | $65.18M → **$25M** | 50% → **25%** | $0.99979 |
+| 19 | weETH / USDC | T1 | USDC | $13.16M → **$2.50M** | $65.87M → **$25M** | 50% → **25%** | $0.99979 |
+| 20 | weETH / USDT | T1 | USDT | $12.99M → **$2.50M** | $65.05M → **$25M** | 50% → **25%** | $0.999409 |
+| 26 | weETH / WBTC | T1 | WBTC | $10.68M → **$100K** | $28.50M → **$1M** | 50% → **25%** | $76,897 |
+| 27 | weETHs / wstETH | T1 | wstETH | $8.45M → **$1M** | $28.19M → **$5M** | 50% → **25%** | $2,620.73 |
+| 32 | weETH / cbBTC | T1 | cbBTC | $10.76M → **$100K** | $50.17M → **$1M** | 50% → **25%** | $77,100 |
+| 56 | sUSDe / GHO | T1 | GHO | $24.14M → **$2.50M** | $120.75M → **$25M** | 50% → **25%** | $0.999374 |
+| 57 | weETH / GHO | T1 | GHO | $9.53M → **$2.50M** | $25.39M → **$25M** | 50% → **25%** | $0.999374 |
+| 74 | weETH-ETH / wstETH | T2 | wstETH | $15.30M → **$2.50M** | $45.26M → **$50M** | 30% → **10%** | $2,620.73 |
+| 80 | weETHs-ETH / wstETH | T2 | wstETH | $4.45M → **$1M** | $5.64M → **$2.50M** | 30% → **25%** | $2,620.73 |
+| 92 | sUSDe-USDT / USDT | T2 | USDT | $21.84M → **$2.50M** | $43.67M → **$25M** | 30% → **25%** | $0.999409 |
+| 93 | USDe-USDT / USDT | T2 | USDT | $15.39M → **$2.50M** | $92.39M → **$25M** | 30% → **25%** | $0.999409 |
+| 94 | eBTC / WBTC | T1 | WBTC | $5.65M → **$100K** | $11.31M → **$1M** | 50% → **25%** | $76,897 |
+| 96 | eBTC-cbBTC / WBTC | T2 | WBTC | $5.65M → **$100K** | $11.31M → **$1M** | 30% → **25%** | $76,897 |
+| 97 | LBTC-cbBTC / WBTC | T2 | WBTC | $4.59M → **$2.50M** | $4.59M → **$25M** | 30% → **25%** | $76,897 |
+| 103 | ezETH / wstETH | T1 | wstETH | $12.23M → **$100K** | $24.46M → **$1M** | 50% → **25%** | $2,620.73 |
+| 104 | ezETH-ETH / wstETH | T2 | wstETH | $9.17M → **$2.50M** | $18.34M → **$25M** | 30% → **25%** | $2,620.73 |
+| 107 | LBTC / USDC | T1 | USDC | $6.34M → **$2.50M** | $19.03M → **$25M** | 50% → **25%** | $0.99979 |
+| 108 | LBTC / USDT | T1 | USDT | $6.28M → **$2.49M** | $18.83M → **$25M** | 50% → **25%** | $0.999409 |
+| 109 | LBTC / GHO | T1 | GHO | $6.09M → **$2.50M** | $18.26M → **$25M** | 50% → **25%** | $0.999374 |
+| 114 | LBTC-cbBTC / cbBTC | T2 | cbBTC | $10.13M → **$2.50M** | $29.55M → **$25M** | 30% → **25%** | $77,100 |
+| 115 | WBTC-LBTC / WBTC | T2 | WBTC | $9.95M → **$2.50M** | $14.90M → **$25M** | 30% → **25%** | $76,897 |
+| 116 | XAUt / USDC | T1 | USDC | $6.29M → **$2.50M** | $12.57M → **$25M** | 50% → **25%** | $0.99979 |
+| 117 | XAUt / USDT | T1 | USDT | $6.23M → **$2.50M** | $12.46M → **$25M** | 50% → **25%** | $0.999409 |
+| 118 | XAUt / GHO | T1 | GHO | $6.02M → **$1M** | $12.03M → **$10M** | 50% → **25%** | $0.999374 |
+| 119 | PAXG / USDC | T1 | USDC | $6.29M → **$2.50M** | $12.57M → **$25M** | 50% → **25%** | $0.99979 |
+| 120 | PAXG / USDT | T1 | USDT | $6.23M → **$2.50M** | $12.46M → **$25M** | 50% → **25%** | $0.999409 |
+| 121 | PAXG / GHO | T1 | GHO | $6.02M → **$1M** | $12.03M → **$10M** | 50% → **25%** | $0.999374 |
+| 122 | PAXG-XAUt / USDC | T2 | USDC | $6.29M → **$1M** | $12.57M → **$2.50M** | 30% → **25%** | $0.99979 |
+| 123 | PAXG-XAUt / USDT | T2 | USDT | $6.23M → **$2.50M** | $12.46M → **$25M** | 30% → **25%** | $0.999409 |
+| 124 | PAXG-XAUt / GHO | T2 | GHO | $6.02M → **$1M** | $12.03M → **$10M** | 30% → **25%** | $0.999374 |
+| 130 | weETH / USDtb | T1 | USDtb | $8.53M → **$1M** | $16.00M → **$2.50M** | 50% → **25%** | $0.999168 |
+| 137 | USDe-USDtb / USDT | T2 | USDT | $6.23M → **$1M** | $24.91M → **$10M** | 30% → **25%** | $0.999409 |
+| 138 | USDe-USDtb / USDC | T2 | USDC | $6.29M → **$1M** | $25.14M → **$10M** | 30% → **25%** | $0.99979 |
+| 140 | USDe-USDtb / GHO | T2 | GHO | $5.99M → **$1M** | $23.97M → **$10M** | 30% → **25%** | $0.999374 |
+| 141 | GHO-USDe / GHO | T2 | GHO | $5.99M → **$1M** | $11.99M → **$10M** | 30% → **25%** | $0.999374 |
+| 145 | syrupUSDC-USDC / USDC | T2 | USDC | $6.18M → **$2.50M** | $24.73M → **$25M** | 30% → **25%** | $0.99979 |
+| 146 | syrupUSDC / USDC | T1 | USDC | $6.16M → **$2.50M** | $61.53M → **$25M** | 50% → **25%** | $0.99979 |
+| 147 | syrupUSDC / USDT | T1 | USDT | $6.12M → **$1M** | $24.48M → **$2.50M** | 50% → **25%** | $0.999409 |
+| 148 | syrupUSDC / GHO | T1 | GHO | $5.87M → **$1M** | $23.49M → **$2.50M** | 50% → **25%** | $0.999374 |
+| 149 | syrupUSDT-USDT / USDT | T2 | USDT | $12.18M → **$2.50M** | $24.36M → **$25M** | 30% → **25%** | $0.999409 |
+| 150 | syrupUSDT / USDC | T1 | USDC | $12.30M → **$1M** | $24.60M → **$2.50M** | 50% → **25%** | $0.99979 |
+| 151 | syrupUSDT / USDT | T1 | USDT | $12.18M → **$2.50M** | $24.36M → **$25M** | 50% → **25%** | $0.999409 |
+| 152 | syrupUSDT / GHO | T1 | GHO | $11.66M → **$100K** | $23.33M → **$1M** | 50% → **25%** | $0.999374 |
+| 153 | osETH / USDC | T1 | USDC | $6.10M → **$100K** | $12.20M → **$1M** | 50% → **25%** | $0.99979 |
+| 154 | osETH / USDT | T1 | USDT | $6.04M → **$100K** | $12.08M → **$1M** | 50% → **25%** | $0.999409 |
+| 155 | osETH / GHO | T1 | GHO | $5.78M → **$100K** | $11.55M → **$1M** | 50% → **25%** | $0.999374 |
+| 159 | ETH-osETH / wstETH | T2 | wstETH | $6.28M → **$2.50M** | $23.54M → **$25M** | 30% → **10%** | $2,620.73 |
+| 160 | reUSD / USDC | T1 | USDC | $9.66M → **$2.50M** | $24.16M → **$20M** | 50% → **10%** | $0.99979 |
+| 161 | reUSD / USDT | T1 | USDT | $9.59M → **$2.50M** | $23.95M → **$20M** | 50% → **10%** | $0.999409 |
+| 162 | reUSD / GHO | T1 | GHO | $9.12M → **$2.50M** | $22.80M → **$20M** | 50% → **25%** | $0.999374 |
+| 164 | reUSD-USDT / USDT | T2 | USDT | $5.99M → **$2.50M** | $11.97M → **$20M** | 30% → **10%** | $0.999409 |
+
+### Action 2: Tighten Smart-Debt Limits on the USDC-USDT (id 2) DEX
+
+DEX id **2**, share price **$2.204907979983792**. Limits are set in DEX shares (1e18) via `setDexBorrowProtocolLimitsInShares`. Expansion window **6h → 3h**.
+
+| Vault | Market | Type | Base (old → new) | Max (old → new) | Expand % |
+| --- | --- | --- | --- | --- | --- |
+| 47 | weETH / USDC-USDT | T3 | $8.27M → **$2.50M** | $22.03M → **$25M** | 30% → **25%** |
+| 50 | sUSDe / USDC-USDT | T3 | $11.02M → **$2.50M** | $44.07M → **$25M** | 30% → **25%** |
+| 98 | sUSDe-USDT / USDC-USDT | T4 | $44.07M → **$2.50M** | $88.13M → **$25M** | 30% → **25%** |
+| 99 | USDe-USDT / USDC-USDT | T4 | $44.07M → **$2.50M** | $88.13M → **$25M** | 30% → **10%** |
+| 156 | osETH / USDC-USDT | T3 | $5.51M → **$100K** | $11.02M → **$1M** | 30% → **25%** |
+| 163 | reUSD / USDC-USDT | T3 | $8.82M → **$2.50M** | $22.03M → **$20M** | 30% → **10%** |
+
+### Action 3: Tighten Smart-Debt Limits on the USDC-USDT (id 34) DEX
+
+DEX id **34**, share price **$2.102974865610295**. Limits are set in DEX shares (1e18) via `setDexBorrowProtocolLimitsInShares`. Expansion window **6h → 3h**.
+
+| Vault | Market | Type | Base (old → new) | Max (old → new) | Expand % |
+| --- | --- | --- | --- | --- | --- |
+| 126 | sUSDe-USDT / USDC-USDT | T4 | $15.77M → **$2.50M** | $42.03M → **$50M** | 30% → **25%** |
+| 127 | USDe-USDT / USDC-USDT | T4 | $15.77M → **$2.50M** | $42.03M → **$50M** | 30% → **25%** |
+| 157 | osETH / USDC-USDT | T3 | $5.25M → **$100K** | $10.51M → **$1M** | 30% → **25%** |
+
+### Action 4: Tighten Smart-Debt Limits on the GHO-USDC (id 4) DEX
+
+DEX id **4**, share price **$2.2159112801948067**. Limits are set in DEX shares (1e18) via `setDexBorrowProtocolLimitsInShares`. Expansion window **6h → 3h**.
+
+| Vault | Market | Type | Base (old → new) | Max (old → new) | Expand % |
+| --- | --- | --- | --- | --- | --- |
+| 61 | GHO-USDC / GHO-USDC | T4 | $9.96M → **$2.50M** | $19.11M → **$25M** | 30% → **10%** |
+| 125 | GHO-sUSDe / GHO-USDC | T4 | $11.07M → **$1M** | $33.23M → **$25M** | 30% → **25%** |
+| 139 | GHO-USDe / GHO-USDC | T4 | $11.07M → **$1M** | $22.14M → **$10M** | 30% → **25%** |
+
+## Description
+
+This is a pure risk-management proposal. Following a review of the less-trusted vault set, borrow capacity is being right-sized down to current usage with tighter, slower expansion so that available debt cannot grow as quickly during stress.
+
+For each vault the new **base debt ceiling** is the limit available immediately, and the **max debt ceiling** is the cap the base can expand toward over time. Lowering the **expand percent** (50%/30% → 25%, or → 10% on the deepest pools) and the **expand duration** (6h → 3h) means the borrowable amount refills more conservatively after utilization.
+
+Liquidity-Layer vaults (Action 1) have their ceilings set in the debt token's own units, converted from the USD targets at the per-vault override price and then normalized by the live borrow exchange price at execution. Smart-debt vaults (Actions 2–4) have their ceilings set directly in DEX shares, converted from USD at each pool's override share price.
+
+The 10% expand tier is applied to the largest / most concentrated pools: vaults **61**, **74**, **99**, **159**, **160**, **161**, **163**, and **164**. All other vaults move to the 25% tier.
+
+## Conclusion
+
+IGP-133 tightens borrow limits on 66 less-trusted Ethereum vaults: 54 at the Liquidity Layer (Action 1) and 12 smart-debt vaults across three DEXes (Actions 2–4). Every affected vault gets lower base/max debt ceilings, a reduced borrow expand percent (25%, or 10% on the deepest pools), and a shortened 3h expansion window, with no changes to supply limits, oracles, or auths.

--- a/contracts/payloads/IGP133/description.md
+++ b/contracts/payloads/IGP133/description.md
@@ -1,16 +1,72 @@
-# Risk-Tightening of Borrow Limits Across 66 Ethereum Vaults
+# IGP-133: Liquidity Layer Upgrades and Borrow Limit Risk Tightening
 
 ## Summary
 
-This proposal lowers borrow-side risk on **66 less-trusted Ethereum vaults** in a single batch. For every affected vault it reduces the base and max debt ceilings, cuts the borrow expansion percent to **25%** (or **10%** on the largest pools), and shortens the borrow expansion window from **6h to 3h**. No supply / withdrawal limits, oracles, auths, or other parameters are touched.
+This proposal combines infrastructure upgrades moved from the original IGP-132 draft with borrow-side risk tightening on **66 less-trusted Ethereum vaults**.
 
-The changes are grouped into four actions: **Action 1** updates 54 vaults that borrow directly at the Liquidity Layer (single batched `updateUserBorrowConfigs`), and **Actions 2–4** update the 12 smart-debt vaults that borrow through a DEX (USDC-USDT id 2, USDC-USDT id 34, and GHO-USDC id 4 respectively).
+**Actions 1–7** register and upgrade the Liquidity Layer **UserModule** and **AdminModule** on the InfiniteProxy (with RollbackModule safety), then rotate Liquidity Layer guardian, DexFactory pause, rates, and range auths. All new implementation and auth addresses are configurable by Team Multisig before execution.
 
-All new ceilings are pre-converted from their USD targets to exact token / share amounts using the per-vault override prices listed in the tables below, so the configured limits are independent of any rounding in the shared price getters.
+**Actions 8–11** lower base/max debt ceilings, cut borrow expansion to **25%** (or **10%** on the largest pools), and shorten the borrow expansion window from **6h to 3h** on every affected vault. Action 8 updates 54 vaults at the Liquidity Layer; Actions 9–11 update smart-debt vaults on three DEXes.
+
+## Configurable Values (Team Multisig sets before execution)
+
+| Variable | Purpose |
+| --- | --- |
+| `newUserModuleAddress` | New UserModule implementation |
+| `newAdminModuleAddress` | New AdminModule implementation |
+| `liquidityPauseAuth` | New Liquidity Layer guardian |
+| `dexPauseAuth` | New DexFactory pause global auth |
+| `newRatesAuth` | New Liquidity Layer rates auth |
+| `newRangeAuth` | New DexFactory range global auth |
+
+Module and auth groups have Team Multisig-only `lock…()` functions. Unset addresses cause the dependent action to revert.
+
+### Old addresses (mainnet)
+
+| Role | Address |
+| --- | --- |
+| Old UserModule | `0x4bDC8816F2f56914B66EbF3786D78872D3a73Ab7` |
+| Old AdminModule | `0xea78faBC13D603895FE9efe8BB4A4F2c56e5698E` |
+| Old Liquidity pause auth | `0xE9332F2d45e3216B7634cA4C7ab88945CD84ab76` |
+| Old Dex pause auth | `0x735BA3772c2cCC0b92Ff6993bd71da88236C1495` |
+| Old rates auth | `0x1e6B029284dc2779F8FfBD83a3a5aA00EdCE6ba4` |
+| Old range auth | `0x827089c01E9f761ff1A6D7041a9388bDdae74cc4` |
 
 ## Code Changes
 
-### Action 1: Tighten Liquidity Layer Borrow Limits (54 vaults)
+### Action 1: Register UserModule LL upgrade on RollbackModule
+
+- Read `newUserModuleAddress` from payload (must be non-zero).
+- `IFluidLiquidityRollback(LIQUIDITY).registerRollbackImplementation(OLD_USER_MODULE, newUserModule_)`.
+
+### Action 2: Upgrade UserModule LL on InfiniteProxy
+
+- Read `newUserModuleAddress` from payload.
+- Copy implementation sigs from `OLD_USER_MODULE`, remove old impl, add new impl with same sigs.
+
+### Action 3: Register AdminModule LL upgrade on RollbackModule
+
+- Read `newAdminModuleAddress` from payload (must be non-zero).
+- `registerRollbackImplementation(OLD_ADMIN_MODULE, newAdminModule_)`.
+
+### Action 4: Upgrade AdminModule LL on InfiniteProxy
+
+- Same pattern as Action 2 for AdminModule.
+
+### Action 5: Set new pause auth contracts
+
+- Liquidity: `updateGuardians` — disable `OLD_LIQUIDITY_PAUSE_AUTH`, enable `liquidityPauseAuth`.
+- DexFactory: `setGlobalAuth(OLD_DEX_PAUSE_AUTH, false)`, `setGlobalAuth(dexPauseAuth, true)`.
+
+### Action 6: Update Rates Auth on Liquidity Layer
+
+- `updateAuths` — disable `OLD_RATES_AUTH`, enable `newRatesAuth`.
+
+### Action 7: Update Ranges Auth on DexFactory
+
+- `setGlobalAuth(OLD_RANGE_AUTH, false)`, `setGlobalAuth(newRangeAuth, true)`.
+
+### Action 8: Tighten Liquidity Layer Borrow Limits (54 vaults)
 
 Batched into one `LIQUIDITY.updateUserBorrowConfigs(...)` call. Expansion window for every row goes **6h → 3h**. Base / max columns show **old → new** USD.
 
@@ -71,7 +127,7 @@ Batched into one `LIQUIDITY.updateUserBorrowConfigs(...)` call. Expansion window
 | 162 | reUSD / GHO | T1 | GHO | $9.12M → **$2.50M** | $22.80M → **$20M** | 50% → **25%** | $0.999374 |
 | 164 | reUSD-USDT / USDT | T2 | USDT | $5.99M → **$2.50M** | $11.97M → **$20M** | 30% → **10%** | $0.999409 |
 
-### Action 2: Tighten Smart-Debt Limits on the USDC-USDT (id 2) DEX
+### Action 9: Tighten Smart-Debt Limits on the USDC-USDT (id 2) DEX
 
 DEX id **2**, share price **$2.204907979983792**. Limits are set in DEX shares (1e18) via `setDexBorrowProtocolLimitsInShares`. Expansion window **6h → 3h**.
 
@@ -84,7 +140,7 @@ DEX id **2**, share price **$2.204907979983792**. Limits are set in DEX shares (
 | 156 | osETH / USDC-USDT | T3 | $5.51M → **$100K** | $11.02M → **$1M** | 30% → **25%** |
 | 163 | reUSD / USDC-USDT | T3 | $8.82M → **$2.50M** | $22.03M → **$20M** | 30% → **10%** |
 
-### Action 3: Tighten Smart-Debt Limits on the USDC-USDT (id 34) DEX
+### Action 10: Tighten Smart-Debt Limits on the USDC-USDT (id 34) DEX
 
 DEX id **34**, share price **$2.102974865610295**. Limits are set in DEX shares (1e18) via `setDexBorrowProtocolLimitsInShares`. Expansion window **6h → 3h**.
 
@@ -94,7 +150,7 @@ DEX id **34**, share price **$2.102974865610295**. Limits are set in DEX shares 
 | 127 | USDe-USDT / USDC-USDT | T4 | $15.77M → **$2.50M** | $42.03M → **$50M** | 30% → **25%** |
 | 157 | osETH / USDC-USDT | T3 | $5.25M → **$100K** | $10.51M → **$1M** | 30% → **25%** |
 
-### Action 4: Tighten Smart-Debt Limits on the GHO-USDC (id 4) DEX
+### Action 11: Tighten Smart-Debt Limits on the GHO-USDC (id 4) DEX
 
 DEX id **4**, share price **$2.2159112801948067**. Limits are set in DEX shares (1e18) via `setDexBorrowProtocolLimitsInShares`. Expansion window **6h → 3h**.
 
@@ -106,14 +162,14 @@ DEX id **4**, share price **$2.2159112801948067**. Limits are set in DEX shares 
 
 ## Description
 
-This is a pure risk-management proposal. Following a review of the less-trusted vault set, borrow capacity is being right-sized down to current usage with tighter, slower expansion so that available debt cannot grow as quickly during stress.
+Following a review of the less-trusted vault set, borrow capacity is being right-sized down to current usage with tighter, slower expansion so that available debt cannot grow as quickly during stress. Module upgrades and auth rotations (Actions 1–7) run first so infrastructure is on the new implementations and auth contracts before limit changes take effect.
 
-For each vault the new **base debt ceiling** is the limit available immediately, and the **max debt ceiling** is the cap the base can expand toward over time. Lowering the **expand percent** (50%/30% → 25%, or → 10% on the deepest pools) and the **expand duration** (6h → 3h) means the borrowable amount refills more conservatively after utilization.
+For each borrow-limit vault the new **base debt ceiling** is the limit available immediately, and the **max debt ceiling** is the cap the base can expand toward over time. Lowering the **expand percent** (50%/30% → 25%, or → 10% on the deepest pools) and the **expand duration** (6h → 3h) means the borrowable amount refills more conservatively after utilization.
 
-Liquidity-Layer vaults (Action 1) have their ceilings set in the debt token's own units, converted from the USD targets at the per-vault override price and then normalized by the live borrow exchange price at execution. Smart-debt vaults (Actions 2–4) have their ceilings set directly in DEX shares, converted from USD at each pool's override share price.
+Liquidity-Layer vaults (Action 8) have their ceilings set in the debt token's own units, converted from the USD targets at the per-vault override price and then normalized by the live borrow exchange price at execution. Smart-debt vaults (Actions 9–11) have their ceilings set directly in DEX shares, converted from USD at each pool's override share price.
 
 The 10% expand tier is applied to the largest / most concentrated pools: vaults **61**, **74**, **99**, **159**, **160**, **161**, **163**, and **164**. All other vaults move to the 25% tier.
 
 ## Conclusion
 
-IGP-133 tightens borrow limits on 66 less-trusted Ethereum vaults: 54 at the Liquidity Layer (Action 1) and 12 smart-debt vaults across three DEXes (Actions 2–4). Every affected vault gets lower base/max debt ceilings, a reduced borrow expand percent (25%, or 10% on the deepest pools), and a shortened 3h expansion window, with no changes to supply limits, oracles, or auths.
+IGP-133 upgrades Liquidity Layer UserModule and AdminModule with rollback safety, rotates pause / rates / range auths (Actions 1–7), then tightens borrow limits on 66 less-trusted Ethereum vaults: 54 at the Liquidity Layer (Action 8) and 12 smart-debt vaults across three DEXes (Actions 9–11). Every affected borrow vault gets lower base/max debt ceilings, a reduced borrow expand percent (25%, or 10% on the deepest pools), and a shortened 3h expansion window.

--- a/contracts/payloads/IGP133/simulation/MockChainlinkFeed.sol
+++ b/contracts/payloads/IGP133/simulation/MockChainlinkFeed.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * Mock Chainlink aggregator for simulation: latestRoundData() returns fixed values.
+ * Used via tenderly_setCode in setup.ts so FluidGenericOracle._readChainlinkSource(feed) gets these values.
+ */
+contract MockChainlinkFeed {
+    function latestRoundData()
+        external
+        pure
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        return (1, 106475560, 1771926611, 1771926611, 1);
+    }
+}

--- a/contracts/payloads/IGP133/simulation/setup.ts
+++ b/contracts/payloads/IGP133/simulation/setup.ts
@@ -1,0 +1,171 @@
+/**
+ * Pre-Setup Script for IGP133 Payload Simulation
+ *
+ * Why this exists:
+ *   `PayloadIGPMain.propose()` ends with `require(proposedId == _PROPOSAL_ID())`,
+ *   and IGP133 hard-codes `PROPOSAL_ID = 133`. The Tenderly fork is taken from
+ *   mainnet, where the GovernorBravo `proposalCount` is still 131 (IGP-132 has
+ *   not been created on-chain yet). Without intervention the simulation's
+ *   `propose()` would be assigned id 132 and revert with "PROPOSAL_IS_NOT_SAME",
+ *   which is exactly the `proposalCreation` failure seen on the PR.
+ *
+ *   This pre-setup creates a single throwaway "IGP-132" proposal so the governor
+ *   advances proposalCount 131 -> 132. The real IGP-133 proposal created later by
+ *   the main simulation flow then lands on id 133 and passes the require check.
+ *
+ * Safety / non-interference:
+ *   - The dummy proposal is created by the PROPOSER EOA (msg.sender to the
+ *     governor), not by the payload contract, so it never collides with the
+ *     "one live proposal per proposer" rule that guards the real IGP-133
+ *     proposal (whose proposer is the freshly deployed payload contract).
+ *   - We temporarily delegate the configured delegator's INST to the proposer to
+ *     comfortably clear the 1,000,000 INST proposal threshold. The main flow's
+ *     own `delegate(delegator -> payload)` step later overwrites this delegation,
+ *     so by IGP-133's voting start the delegator's weight sits on the payload and
+ *     the proposer is back to its baseline votes. The real vote tally (cast by
+ *     the large delegates in simulation-config.yml) is therefore unchanged.
+ *   - The dummy proposal is never voted on, queued, or executed; it simply
+ *     occupies id 132 and is left to expire/defeat.
+ */
+
+import { JsonRpcProvider, ethers } from "ethers";
+
+const GOVERNOR = "0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B";
+const TIMELOCK = "0x2386DC45AdDed673317eF068992F19421B481F4c";
+const INST = "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb";
+
+// Matches addresses.delegator / addresses.proposer in config/simulation-config.yml.
+const DELEGATOR = "0x5AAB0630aaCa6d0bf1c310aF6C2BB3826A951cFb";
+const PROPOSER = "0xA45f7bD6A5Ff45D31aaCE6bCD3d426D9328cea01";
+
+// IGP133 hard-codes PROPOSAL_ID = 133, so the governor must be at count 132
+// before the real proposal is created.
+const IGP133_PROPOSAL_ID = 133;
+const TARGET_PROPOSAL_COUNT = IGP133_PROPOSAL_ID - 1; // 132
+
+async function getProposalCount(provider: JsonRpcProvider): Promise<number> {
+  const iface = new ethers.Interface([
+    "function proposalCount() view returns (uint256)",
+  ]);
+  const result = await provider.send("eth_call", [
+    { to: GOVERNOR, data: iface.encodeFunctionData("proposalCount", []) },
+    "latest",
+  ]);
+  return Number(
+    ethers.AbiCoder.defaultAbiCoder().decode(["uint256"], result)[0],
+  );
+}
+
+async function sendTx(
+  provider: JsonRpcProvider,
+  from: string,
+  to: string,
+  data: string,
+  label: string,
+): Promise<void> {
+  const txHash = await provider.send("eth_sendTransaction", [
+    {
+      from,
+      to,
+      data,
+      value: "0x0",
+      gas: "0x989680",
+      gasPrice: "0x0",
+    },
+  ]);
+  const receipt = await provider.waitForTransaction(txHash);
+  if (!receipt || receipt.status !== 1) {
+    throw new Error(`${label} transaction failed (tx ${txHash})`);
+  }
+  console.log(`[SETUP] ${label} succeeded (${txHash})`);
+}
+
+async function createDummyProposal(provider: JsonRpcProvider): Promise<void> {
+  // 1. Park the delegator's INST on the proposer so it clears the 1M threshold
+  //    with margin. Overwritten later by the main flow's delegate(-> payload).
+  const delegateData = new ethers.Interface([
+    "function delegate(address delegatee)",
+  ]).encodeFunctionData("delegate", [PROPOSER]);
+  await sendTx(
+    provider,
+    DELEGATOR,
+    INST,
+    delegateData,
+    "delegate INST (delegator -> proposer) for dummy IGP-132",
+  );
+
+  // 2. Create a minimal, never-executed proposal so proposalCount advances by 1.
+  const targets = [TIMELOCK];
+  const values = [0];
+  const signatures = [""];
+  const calldatas = ["0x"];
+  const description =
+    "IGP-132 placeholder (simulation only): consumes governor proposal id 132 so IGP-133 lands on id 133.";
+
+  const proposeData = new ethers.Interface([
+    "function propose(address[] targets, uint256[] values, string[] signatures, bytes[] calldatas, string description) returns (uint256)",
+  ]).encodeFunctionData("propose", [
+    targets,
+    values,
+    signatures,
+    calldatas,
+    description,
+  ]);
+  await sendTx(
+    provider,
+    PROPOSER,
+    GOVERNOR,
+    proposeData,
+    "create dummy IGP-132 proposal",
+  );
+}
+
+export async function preSetup(
+  provider: JsonRpcProvider,
+  _payloadAddress?: string,
+): Promise<void> {
+  console.log("[SETUP] Running pre-setup for IGP133...");
+
+  try {
+    const count = await getProposalCount(provider);
+    console.log(`[SETUP] Current governor proposalCount = ${count}`);
+
+    const needed = TARGET_PROPOSAL_COUNT - count;
+
+    if (needed <= 0) {
+      console.log(
+        `[SETUP] proposalCount (${count}) already >= ${TARGET_PROPOSAL_COUNT}; ` +
+          `IGP-133 will land on id ${count + 1}. No dummy proposal created.`,
+      );
+      return;
+    }
+
+    if (needed > 1) {
+      // GovernorBravo allows only one live proposal per proposer, so a single
+      // proposer cannot fill a gap larger than one in a single pass.
+      throw new Error(
+        `Need ${needed} dummy proposals to reach proposalCount ${TARGET_PROPOSAL_COUNT} ` +
+          `(current ${count}), but this setup only creates one. Investigate the fork state.`,
+      );
+    }
+
+    await createDummyProposal(provider);
+
+    const after = await getProposalCount(provider);
+    console.log(
+      `[SETUP] proposalCount after dummy = ${after} (next proposal -> id ${after + 1})`,
+    );
+    if (after + 1 !== IGP133_PROPOSAL_ID) {
+      throw new Error(
+        `After dummy proposal the next id would be ${after + 1}, expected ${IGP133_PROPOSAL_ID}.`,
+      );
+    }
+
+    console.log("[SETUP] Pre-setup completed successfully");
+  } catch (error: any) {
+    console.error("[SETUP] Pre-setup failed:", error.message);
+    throw error;
+  }
+}
+
+export default preSetup;

--- a/contracts/payloads/IGP133/simulation/setup.ts
+++ b/contracts/payloads/IGP133/simulation/setup.ts
@@ -1,47 +1,68 @@
 /**
  * Pre-Setup Script for IGP133 Payload Simulation
  *
- * Why this exists:
- *   `PayloadIGPMain.propose()` ends with `require(proposedId == _PROPOSAL_ID())`,
- *   and IGP133 hard-codes `PROPOSAL_ID = 133`. The Tenderly fork is taken from
- *   mainnet, where the GovernorBravo `proposalCount` is still 131 (IGP-132 has
- *   not been created on-chain yet). Without intervention the simulation's
- *   `propose()` would be assigned id 132 and revert with "PROPOSAL_IS_NOT_SAME",
- *   which is exactly the `proposalCreation` failure seen on the PR.
- *
- *   This pre-setup creates a single throwaway "IGP-132" proposal so the governor
- *   advances proposalCount 131 -> 132. The real IGP-133 proposal created later by
- *   the main simulation flow then lands on id 133 and passes the require check.
- *
- * Safety / non-interference:
- *   - The dummy proposal is created by the PROPOSER EOA (msg.sender to the
- *     governor), not by the payload contract, so it never collides with the
- *     "one live proposal per proposer" rule that guards the real IGP-133
- *     proposal (whose proposer is the freshly deployed payload contract).
- *   - We temporarily delegate the configured delegator's INST to the proposer to
- *     comfortably clear the 1,000,000 INST proposal threshold. The main flow's
- *     own `delegate(delegator -> payload)` step later overwrites this delegation,
- *     so by IGP-133's voting start the delegator's weight sits on the payload and
- *     the proposer is back to its baseline votes. The real vote tally (cast by
- *     the large delegates in simulation-config.yml) is therefore unchanged.
- *   - The dummy proposal is never voted on, queued, or executed; it simply
- *     occupies id 132 and is left to expire/defeat.
+ * 1. Governor proposalCount bump: create a throwaway IGP-132 placeholder proposal so
+ *    the real IGP-133 lands on id 133 (PayloadIGP133 hard-codes PROPOSAL_ID = 133).
+ * 2. Mock Chainlink feed 0x66ac... for oracle-dependent vault paths (e.g. osETH).
+ * 3. Clone mainnet module/auth bytecode to simulation-only addresses and set them
+ *    on the payload via Team Multisig configurators (actions 1–7).
  */
 
 import { JsonRpcProvider, ethers } from "ethers";
+import * as fs from "fs";
+import * as path from "path";
 
 const GOVERNOR = "0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B";
 const TIMELOCK = "0x2386DC45AdDed673317eF068992F19421B481F4c";
 const INST = "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb";
+const TEAM_MULTISIG = "0x4F6F977aCDD1177DCD81aB83074855EcB9C2D49e";
 
-// Matches addresses.delegator / addresses.proposer in config/simulation-config.yml.
 const DELEGATOR = "0x5AAB0630aaCa6d0bf1c310aF6C2BB3826A951cFb";
 const PROPOSER = "0xA45f7bD6A5Ff45D31aaCE6bCD3d426D9328cea01";
 
-// IGP133 hard-codes PROPOSAL_ID = 133, so the governor must be at count 132
-// before the real proposal is created.
 const IGP133_PROPOSAL_ID = 133;
 const TARGET_PROPOSAL_COUNT = IGP133_PROPOSAL_ID - 1; // 132
+
+/** Chainlink feed mocked so latestRoundData() returns (1, 106475560, 1771926611, 1771926611, 1) */
+const CHAINLINK_FEED_TO_MOCK = "0x66ac817f997efd114edfcccdce99f3268557b32c";
+
+/** Matches PayloadIGP133 OLD_* constants — bytecode is cloned to SIM_* below. */
+const OLD_USER_MODULE = "0x4bDC8816F2f56914B66EbF3786D78872D3a73Ab7";
+const OLD_ADMIN_MODULE = "0xea78faBC13D603895FE9efe8BB4A4F2c56e5698E";
+const OLD_LIQUIDITY_PAUSE_AUTH = "0xE9332F2d45e3216B7634cA4C7ab88945CD84ab76";
+const OLD_DEX_PAUSE_AUTH = "0x735BA3772c2cCC0b92Ff6993bd71da88236C1495";
+const OLD_RATES_AUTH = "0x1e6B029284dc2779F8FfBD83a3a5aA00EdCE6ba4";
+const OLD_RANGE_AUTH = "0x827089c01E9f761ff1A6D7041a9388bDdae74cc4";
+
+const SIM_NEW_USER_MODULE = "0x0000000000000000000000000000000000000101";
+const SIM_NEW_ADMIN_MODULE = "0x0000000000000000000000000000000000000102";
+const SIM_LIQUIDITY_PAUSE_AUTH = "0x0000000000000000000000000000000000000103";
+const SIM_DEX_PAUSE_AUTH = "0x0000000000000000000000000000000000000104";
+const SIM_RATES_AUTH = "0x0000000000000000000000000000000000000105";
+const SIM_RANGE_AUTH = "0x0000000000000000000000000000000000000106";
+
+function normalizeHex(raw: string): string {
+  return raw.startsWith("0x") ? raw : `0x${raw}`;
+}
+
+function readArtifactBytecode(relativeArtifactPath: string): string {
+  const artifactPath = path.join(process.cwd(), relativeArtifactPath);
+  if (!fs.existsSync(artifactPath)) {
+    throw new Error(
+      `Artifact not found at ${artifactPath}. Run 'npm run compile' first.`,
+    );
+  }
+
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf-8"));
+  const raw =
+    artifact.deployedBytecode?.object ?? artifact.deployedBytecode ?? "";
+  const bytecode =
+    typeof raw === "string" && raw.length > 0 ? normalizeHex(raw) : "";
+  if (!bytecode) {
+    throw new Error(`${artifactPath} has no deployedBytecode.object`);
+  }
+  return bytecode;
+}
 
 async function getProposalCount(provider: JsonRpcProvider): Promise<number> {
   const iface = new ethers.Interface([
@@ -81,8 +102,6 @@ async function sendTx(
 }
 
 async function createDummyProposal(provider: JsonRpcProvider): Promise<void> {
-  // 1. Park the delegator's INST on the proposer so it clears the 1M threshold
-  //    with margin. Overwritten later by the main flow's delegate(-> payload).
   const delegateData = new ethers.Interface([
     "function delegate(address delegatee)",
   ]).encodeFunctionData("delegate", [PROPOSER]);
@@ -94,7 +113,6 @@ async function createDummyProposal(provider: JsonRpcProvider): Promise<void> {
     "delegate INST (delegator -> proposer) for dummy IGP-132",
   );
 
-  // 2. Create a minimal, never-executed proposal so proposalCount advances by 1.
   const targets = [TIMELOCK];
   const values = [0];
   const signatures = [""];
@@ -120,44 +138,172 @@ async function createDummyProposal(provider: JsonRpcProvider): Promise<void> {
   );
 }
 
+async function ensureGovernorProposalId(provider: JsonRpcProvider): Promise<void> {
+  const count = await getProposalCount(provider);
+  console.log(`[SETUP] Current governor proposalCount = ${count}`);
+
+  const needed = TARGET_PROPOSAL_COUNT - count;
+
+  if (needed <= 0) {
+    console.log(
+      `[SETUP] proposalCount (${count}) already >= ${TARGET_PROPOSAL_COUNT}; ` +
+        `IGP-133 will land on id ${count + 1}. No dummy proposal created.`,
+    );
+    return;
+  }
+
+  if (needed > 1) {
+    throw new Error(
+      `Need ${needed} dummy proposals to reach proposalCount ${TARGET_PROPOSAL_COUNT} ` +
+        `(current ${count}), but this setup only creates one. Investigate the fork state.`,
+    );
+  }
+
+  await createDummyProposal(provider);
+
+  const after = await getProposalCount(provider);
+  console.log(
+    `[SETUP] proposalCount after dummy = ${after} (next proposal -> id ${after + 1})`,
+  );
+  if (after + 1 !== IGP133_PROPOSAL_ID) {
+    throw new Error(
+      `After dummy proposal the next id would be ${after + 1}, expected ${IGP133_PROPOSAL_ID}.`,
+    );
+  }
+}
+
+async function mockChainlinkFeed(provider: JsonRpcProvider): Promise<void> {
+  const bytecode = readArtifactBytecode(
+    "artifacts/contracts/payloads/IGP133/simulation/MockChainlinkFeed.sol/MockChainlinkFeed.json",
+  );
+  await provider.send("tenderly_setCode", [CHAINLINK_FEED_TO_MOCK, bytecode]);
+  console.log("[SETUP] Mocked Chainlink feed for OSETH oracle path");
+}
+
+async function cloneBytecode(
+  provider: JsonRpcProvider,
+  source: string,
+  target: string,
+  label: string,
+): Promise<void> {
+  const code = await provider.getCode(source);
+  if (code === "0x") {
+    throw new Error(`${label}: source ${source} has no code on this fork`);
+  }
+  await provider.send("tenderly_setCode", [target, code]);
+  console.log(`[SETUP] Cloned ${label} bytecode ${source} -> ${target}`);
+}
+
+async function prepareSimulationTargets(
+  provider: JsonRpcProvider,
+): Promise<void> {
+  await cloneBytecode(
+    provider,
+    OLD_USER_MODULE,
+    SIM_NEW_USER_MODULE,
+    "new UserModule",
+  );
+  await cloneBytecode(
+    provider,
+    OLD_ADMIN_MODULE,
+    SIM_NEW_ADMIN_MODULE,
+    "new AdminModule",
+  );
+  await cloneBytecode(
+    provider,
+    OLD_LIQUIDITY_PAUSE_AUTH,
+    SIM_LIQUIDITY_PAUSE_AUTH,
+    "new Liquidity pause auth",
+  );
+  await cloneBytecode(
+    provider,
+    OLD_DEX_PAUSE_AUTH,
+    SIM_DEX_PAUSE_AUTH,
+    "new Dex pause auth",
+  );
+  await cloneBytecode(
+    provider,
+    OLD_RATES_AUTH,
+    SIM_RATES_AUTH,
+    "new rates auth",
+  );
+  await cloneBytecode(
+    provider,
+    OLD_RANGE_AUTH,
+    SIM_RANGE_AUTH,
+    "new range auth",
+  );
+}
+
+async function setConfigurableAddresses(
+  provider: JsonRpcProvider,
+  payloadAddress: string,
+): Promise<void> {
+  const iface = new ethers.Interface([
+    "function setNewUserModuleAddress(address) external",
+    "function setNewAdminModuleAddress(address) external",
+    "function setPauseAuths(address,address) external",
+    "function setNewRatesAuth(address) external",
+    "function setNewRangeAuth(address) external",
+  ]);
+
+  const calls: { name: string; data: string }[] = [
+    {
+      name: "setNewUserModuleAddress",
+      data: iface.encodeFunctionData("setNewUserModuleAddress", [
+        SIM_NEW_USER_MODULE,
+      ]),
+    },
+    {
+      name: "setNewAdminModuleAddress",
+      data: iface.encodeFunctionData("setNewAdminModuleAddress", [
+        SIM_NEW_ADMIN_MODULE,
+      ]),
+    },
+    {
+      name: "setPauseAuths",
+      data: iface.encodeFunctionData("setPauseAuths", [
+        SIM_LIQUIDITY_PAUSE_AUTH,
+        SIM_DEX_PAUSE_AUTH,
+      ]),
+    },
+    {
+      name: "setNewRatesAuth",
+      data: iface.encodeFunctionData("setNewRatesAuth", [SIM_RATES_AUTH]),
+    },
+    {
+      name: "setNewRangeAuth",
+      data: iface.encodeFunctionData("setNewRangeAuth", [SIM_RANGE_AUTH]),
+    },
+  ];
+
+  for (const call of calls) {
+    await sendTx(
+      provider,
+      TEAM_MULTISIG,
+      payloadAddress,
+      call.data,
+      call.name,
+    );
+  }
+}
+
 export async function preSetup(
   provider: JsonRpcProvider,
-  _payloadAddress?: string,
+  payloadAddress?: string,
 ): Promise<void> {
   console.log("[SETUP] Running pre-setup for IGP133...");
 
   try {
-    const count = await getProposalCount(provider);
-    console.log(`[SETUP] Current governor proposalCount = ${count}`);
+    await ensureGovernorProposalId(provider);
+    await mockChainlinkFeed(provider);
+    await prepareSimulationTargets(provider);
 
-    const needed = TARGET_PROPOSAL_COUNT - count;
-
-    if (needed <= 0) {
-      console.log(
-        `[SETUP] proposalCount (${count}) already >= ${TARGET_PROPOSAL_COUNT}; ` +
-          `IGP-133 will land on id ${count + 1}. No dummy proposal created.`,
-      );
-      return;
-    }
-
-    if (needed > 1) {
-      // GovernorBravo allows only one live proposal per proposer, so a single
-      // proposer cannot fill a gap larger than one in a single pass.
-      throw new Error(
-        `Need ${needed} dummy proposals to reach proposalCount ${TARGET_PROPOSAL_COUNT} ` +
-          `(current ${count}), but this setup only creates one. Investigate the fork state.`,
-      );
-    }
-
-    await createDummyProposal(provider);
-
-    const after = await getProposalCount(provider);
-    console.log(
-      `[SETUP] proposalCount after dummy = ${after} (next proposal -> id ${after + 1})`,
-    );
-    if (after + 1 !== IGP133_PROPOSAL_ID) {
-      throw new Error(
-        `After dummy proposal the next id would be ${after + 1}, expected ${IGP133_PROPOSAL_ID}.`,
+    if (payloadAddress) {
+      await setConfigurableAddresses(provider, payloadAddress);
+    } else {
+      console.warn(
+        "[SETUP] No payload address provided, skipping configurable address setup",
       );
     }
 


### PR DESCRIPTION
## Summary

Risk-tightening of borrow limits across **66 less-trusted Ethereum vaults** in a single batch. For every affected vault this lowers the base and max debt ceilings, cuts the borrow expansion percent to **25%** (or **10%** on the largest / most concentrated pools), and shortens the borrow expansion window from **6h → 3h**. No supply / withdrawal limits, oracles, auths, or other parameters are touched.

## Actions

- **Action 1** — Tighten Liquidity Layer borrow limits on **54 vaults** via a single batched `LIQUIDITY.updateUserBorrowConfigs(...)` call. Ceilings are set in each debt token's own units, converted from USD targets at per-vault override prices and normalized by the live borrow exchange price at execution.
- **Action 2** — Tighten smart-debt limits on the **USDC-USDT (id 2)** DEX (6 vaults) via `setDexBorrowProtocolLimitsInShares`.
- **Action 3** — Tighten smart-debt limits on the **USDC-USDT (id 34)** DEX (3 vaults).
- **Action 4** — Tighten smart-debt limits on the **GHO-USDC (id 4)** DEX (3 vaults).

## Details

- New **base debt ceiling** = limit available immediately; **max debt ceiling** = cap the base expands toward over time.
- Expand percent reduced from 50%/30% → **25%**, or → **10%** on the deepest pools (vaults 61, 74, 99, 159, 160, 161, 163, 164).
- Expand duration reduced **6h → 3h** for all affected vaults.
- All new ceilings are pre-converted from USD targets to exact token / share amounts using per-vault override prices, so configured limits are independent of rounding in the shared price getters.

This is a pure risk-management proposal: borrow capacity is right-sized down to current usage with tighter, slower expansion so available debt cannot grow as quickly during stress.

See `contracts/payloads/IGP133/description.md` for the full per-vault tables.

## IGP Actions

```solidity
// Action 1: Register UserModule LL upgrade on RollbackModule
// Action 2: Upgrade UserModule LL on InfiniteProxy
// Action 3: Register AdminModule LL upgrade on RollbackModule
// Action 4: Upgrade AdminModule LL on InfiniteProxy
// Action 5: Set new pause auth contracts
// Action 6: Update Rates Auth on Liquidity Layer
// Action 7: Update Ranges Auth on DexFactory
// Action 8: Tighten Liquidity Layer borrow limits on 54 vaults
// Action 9: Tighten smart-debt limits on the USDC-USDT DEX (id 2)
// Action 10: Tighten smart-debt limits on the USDC-USDT DEX (id 34)
// Action 11: Tighten smart-debt limits on the GHO-USDC DEX (id 4)
```