### PR TITLE
IGP-140: launch the weETH/ETH T1 vault (id 182) at dust limits

### DIFF
--- a/contracts/payloads/IGP140/PayloadIGP140.sol
+++ b/contracts/payloads/IGP140/PayloadIGP140.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.21;
+pragma experimental ABIEncoderV2;
+
+import {PayloadIGPPriceHelpers} from "../common/pricehelpers.sol";
+
+/// @notice IGP140: Launch the weETH/ETH T1 vault (id 182) at dust limits.
+///
+///         Action 1 sets the vault's Liquidity Layer supply and borrow limits
+///         and grants Team Multisig vault auth so limits can be scaled up
+///         post-launch without another proposal.
+///
+///         The vault was deployed by the Team Multisig at block 25,789,585
+///         (0x0b8a681ed46EA8ec6b97D686dF0631fBf84B03d2) and is still
+///         unconfigured at the Liquidity Layer, so it cannot be used until
+///         this payload executes.
+///
+///         This action was originally Action 2 of IGP-139 (the Foundation
+///         grant). It moved here because the vault-auth call went to the
+///         factory instead of the factory's owner and reverted the whole
+///         proposal on execution; the grant has no dependency on the vault
+///         launch.
+contract PayloadIGP140 is PayloadIGPPriceHelpers {
+    uint256 public constant PROPOSAL_ID = 140;
+
+    /// @notice weETH/ETH T1 vault, deployed via the Team Multisig.
+    uint256 public constant VAULT_WEETH_ETH_ID = 182; // T1: weETH / ETH
+
+    function execute() public virtual override {
+        super.execute();
+
+        // Action 1: Set dust limits for weETH/ETH T1 vault.
+        action1();
+    }
+
+    function verifyProposal() public view override {}
+
+    function _PROPOSAL_ID() internal view override returns (uint256) {
+        return PROPOSAL_ID;
+    }
+
+    /**
+     * |
+     * |     Proposal Payload Actions      |
+     * |__________________________________
+     */
+
+    /// @notice Action 1: Set dust limits for the weETH/ETH T1 vault (id 182)
+    ///         and grant Team Multisig vault auth.
+    /// @dev Vault auth goes through `VAULT_FACTORY_WRAPPER_OWNER`, not the
+    ///      factory itself: `setVaultAuth` is `onlyOwner` on the factory and
+    ///      the factory is owned by that wrapper, which the timelock is
+    ///      authorized on. Calling the factory directly reverts UNAUTHORIZED.
+    function action1() internal isActionSkippable(1) {
+        address weETH_ETH_VAULT = getVaultAddress(VAULT_WEETH_ETH_ID);
+
+        // [TYPE 1] weETH/ETH vault - Dust limits
+        VaultConfig memory VAULT_weETH_ETH = VaultConfig({
+            vault: weETH_ETH_VAULT,
+            vaultType: VAULT_TYPE.TYPE_1,
+            supplyToken: weETH_ADDRESS,
+            borrowToken: ETH_ADDRESS,
+            baseWithdrawalLimitInUSD: 7_000, // $7k
+            baseBorrowLimitInUSD: 7_000, // $7k
+            maxBorrowLimitInUSD: 9_000 // $9k
+        });
+
+        setVaultLimits(VAULT_weETH_ETH);
+
+        VAULT_FACTORY_WRAPPER_OWNER.setVaultAuth(
+            weETH_ETH_VAULT,
+            TEAM_MULTISIG,
+            true
+        );
+    }
+
+    /**
+     * |
+     * |     Payload Actions End Here      |
+     * |__________________________________
+     */
+
+    // --- BEGIN AUTO-GENERATED PRICES (scripts/verify/prepare-prices.ts) ---
+    // fetched: 2026-08-24T19:48:26.071Z, source: coingecko
+    function ETH_USD_PRICE()   public pure override returns (uint256) { return 2_470 * 1e2; }
+    function weETH_USD_PRICE() public pure override returns (uint256) { return 2_720 * 1e2; }
+    // --- END AUTO-GENERATED PRICES ---
+}

--- a/contracts/payloads/IGP140/PayloadIGP140.sol
+++ b/contracts/payloads/IGP140/PayloadIGP140.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.21;
 pragma experimental ABIEncoderV2;
 
 import {PayloadIGPPriceHelpers} from "../common/pricehelpers.sol";
+import {IFluidDex} from "../common/interfaces/IFluidDex.sol";
 
 /// @notice IGP140: Launch the weETH/ETH T1 vault (id 182) at dust limits.
 ///
@@ -20,17 +21,27 @@ import {PayloadIGPPriceHelpers} from "../common/pricehelpers.sol";
 ///         factory instead of the factory's owner and reverted the whole
 ///         proposal on execution; the grant has no dependency on the vault
 ///         launch.
+///
+///         Action 2 reduces the deprecated USDC-ETH DEX (5) max supply and
+///         max borrow shares to ~$1M each (500k shares at ~$2/share), down
+///         from 7.5M / 5M shares (~$15M / $10M).
 contract PayloadIGP140 is PayloadIGPPriceHelpers {
     uint256 public constant PROPOSAL_ID = 140;
 
     /// @notice weETH/ETH T1 vault, deployed via the Team Multisig.
     uint256 public constant VAULT_WEETH_ETH_ID = 182; // T1: weETH / ETH
 
+    /// @notice Deprecated USDC-ETH DEX (dust-ceilinged since IGP-96).
+    uint256 public constant USDC_ETH_DEX_ID = 5;
+
     function execute() public virtual override {
         super.execute();
 
         // Action 1: Set dust limits for weETH/ETH T1 vault.
         action1();
+
+        // Action 2: Reduce USDC-ETH DEX (5) max supply and borrow shares to ~$1M.
+        action2();
     }
 
     function verifyProposal() public view override {}
@@ -71,6 +82,22 @@ contract PayloadIGP140 is PayloadIGPPriceHelpers {
             weETH_ETH_VAULT,
             TEAM_MULTISIG,
             true
+        );
+    }
+
+    /// @notice Action 2: Reduce the deprecated USDC-ETH DEX (5) max supply
+    ///         shares and max borrow shares to ~$1M each. The pool has been
+    ///         dust-ceilinged since IGP-96 and holds only dust liquidity
+    ///         (~101 supply / ~100 borrow shares), so the old 7.5M / 5M share
+    ///         caps (~$15M / $10M) are unnecessary surface area.
+    function action2() internal isActionSkippable(2) {
+        address usdcEthDex_ = getDexAddress(USDC_ETH_DEX_ID);
+
+        IFluidDex(usdcEthDex_).updateMaxSupplyShares(
+            500_000 * 1e18 // ~$1M at ~$2/share (from 7.5M shares)
+        );
+        IFluidDex(usdcEthDex_).updateMaxBorrowShares(
+            500_000 * 1e18 // ~$1M at ~$2/share (from 5M shares)
         );
     }
 

--- a/contracts/payloads/IGP140/description.md
+++ b/contracts/payloads/IGP140/description.md
@@ -1,8 +1,8 @@
-# Launch the weETH/ETH Vault at Dust Limits
+# Launch the weETH/ETH Vault at Dust Limits and Reduce USDC-ETH DEX Share Caps
 
 ## Summary
 
-This proposal brings the new **weETH/ETH** T1 vault (id **182**) online by setting its Liquidity Layer limits at dust size and granting the Team Multisig vault auth so limits can be scaled up as the market proves out.
+This proposal brings the new **weETH/ETH** T1 vault (id **182**) online by setting its Liquidity Layer limits at dust size and granting the Team Multisig vault auth so limits can be scaled up as the market proves out. It also reduces the deprecated **USDC-ETH DEX (5)** max supply and max borrow shares to **~$1M** each.
 
 The vault contract was deployed by the Team Multisig at block 25,789,585 and is still unconfigured at the Liquidity Layer, so it cannot be supplied to or borrowed from until this payload executes.
 
@@ -21,6 +21,17 @@ The vault contract was deployed by the Team Multisig at block 25,789,585 and is 
 - Limits are set at the Liquidity Layer via `setVaultLimits` with the standard dust-limit config: 50% expansion over 6 hours.
 - Team Multisig is granted vault auth so it can raise limits post-launch without a further proposal. The call goes through the VaultFactoryOwner wrapper (`0xB031913cB7AD81b8A4Ba412B471c2dA69BEA410B`), which owns the vault factory and which the timelock is authorized on.
 
+### Action 2: Reduce USDC-ETH DEX (5) Max Supply and Borrow Shares to ~$1M
+
+- **DEX**: `0x2886a01a0645390872a9eb99dAe1283664b0c524` (USDC-ETH, id 5)
+
+| Parameter | Current | New |
+| --- | --- | --- |
+| Max supply shares | `7.5M` (~$15M) | `500k` (~$1M at ~$2/share) |
+| Max borrow shares | `5M` (~$10M) | `500k` (~$1M at ~$2/share) |
+
+The DEX has been deprecated since IGP-96 dust-ceilinged its borrow limits and currently holds only dust liquidity (~101 supply / ~100 borrow shares). Calls: `updateMaxSupplyShares(500_000e18)` and `updateMaxBorrowShares(500_000e18)`.
+
 ## Description
 
 weETH/ETH is a correlated-pair leverage market: users supply weETH and borrow ETH to loop into ether.fi staking yield. Fluid already runs weETH markets against stablecoins and wstETH, plus a weETH-ETH DEX (id 9), so both legs are established collateral at the Liquidity Layer.
@@ -31,4 +42,4 @@ This action was originally Action 2 of IGP-139, the Foundation grant payload. It
 
 ## Conclusion
 
-IGP-140 launches the weETH/ETH T1 vault (id 182) with $7k base withdrawal, $7k base borrow, and $9k max borrow limits at the Liquidity Layer, and grants the Team Multisig vault auth for post-launch scaling.
+IGP-140 launches the weETH/ETH T1 vault (id 182) with $7k base withdrawal, $7k base borrow, and $9k max borrow limits at the Liquidity Layer, grants the Team Multisig vault auth for post-launch scaling, and reduces the deprecated USDC-ETH DEX (5) max supply and max borrow shares to ~$1M each.

--- a/contracts/payloads/IGP140/description.md
+++ b/contracts/payloads/IGP140/description.md
@@ -1,0 +1,34 @@
+# Launch the weETH/ETH Vault at Dust Limits
+
+## Summary
+
+This proposal brings the new **weETH/ETH** T1 vault (id **182**) online by setting its Liquidity Layer limits at dust size and granting the Team Multisig vault auth so limits can be scaled up as the market proves out.
+
+The vault contract was deployed by the Team Multisig at block 25,789,585 and is still unconfigured at the Liquidity Layer, so it cannot be supplied to or borrowed from until this payload executes.
+
+## Code Changes
+
+### Action 1: Set Dust Limits for the weETH/ETH T1 Vault (id 182)
+
+- **Vault**: `0x0b8a681ed46EA8ec6b97D686dF0631fBf84B03d2` (T1, weETH collateral / ETH debt)
+- **Collateral**: weETH (`0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee`)
+- **Debt**: ETH (`0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`)
+
+| Vault | Type | Market | Limits |
+| --- | --- | --- | --- |
+| 182 | T1 | weETH / ETH | Withdrawal base `$7k`, Borrow `$7k / $9k` (LL) |
+
+- Limits are set at the Liquidity Layer via `setVaultLimits` with the standard dust-limit config: 50% expansion over 6 hours.
+- Team Multisig is granted vault auth so it can raise limits post-launch without a further proposal. The call goes through the VaultFactoryOwner wrapper (`0xB031913cB7AD81b8A4Ba412B471c2dA69BEA410B`), which owns the vault factory and which the timelock is authorized on.
+
+## Description
+
+weETH/ETH is a correlated-pair leverage market: users supply weETH and borrow ETH to loop into ether.fi staking yield. Fluid already runs weETH markets against stablecoins and wstETH, plus a weETH-ETH DEX (id 9), so both legs are established collateral at the Liquidity Layer.
+
+New markets launch at dust limits by convention. The $7k / $9k ceilings cap total exposure while the vault's oracle and liquidation behaviour are observed under real usage, and the Team Multisig auth lets limits be raised incrementally once it is behaving as expected rather than requiring a governance cycle per step.
+
+This action was originally Action 2 of IGP-139, the Foundation grant payload. It targeted the vault factory directly for the vault-auth call, which reverts because the factory's `setVaultAuth` is owner-gated and the factory is owned by the wrapper contract rather than the timelock. That reverted IGP-139 in full during simulation. Splitting the vault launch into its own payload unblocks the grant, which has no dependency on this market, and corrects the auth routing.
+
+## Conclusion
+
+IGP-140 launches the weETH/ETH T1 vault (id 182) with $7k base withdrawal, $7k base borrow, and $9k max borrow limits at the Liquidity Layer, and grants the Team Multisig vault auth for post-launch scaling.

--- a/contracts/payloads/IGP140/simulation/setup.ts
+++ b/contracts/payloads/IGP140/simulation/setup.ts
@@ -1,0 +1,272 @@
+/**
+ * Pre-Setup Script for IGP140 Payload Simulation
+ *
+ * 1. Governor proposalCount bump: create throwaway placeholder proposals if the
+ *    fork's proposalCount has fallen behind, so the real IGP-140 lands on id
+ *    140 (PayloadIGP140 hard-codes PROPOSAL_ID = 140).
+ *
+ *    Mainnet proposalCount is 138, and IGP-139 (Foundation grant) takes 139, so
+ *    this normally creates one placeholder to consume id 139.
+ *
+ * 2. Assert the weETH/ETH vault (id 182) is deployed on the fork. It was
+ *    deployed by the Team Multisig at block 25,789,585, so any recent fork has
+ *    it. We assert rather than deploy: the Liquidity Layer rejects supply/borrow
+ *    configs for an address with no code, and if the vault is missing the fork
+ *    is stale in a way worth surfacing rather than papering over.
+ */
+
+import { JsonRpcProvider, ethers } from "ethers";
+
+const GOVERNOR = "0x0204Cd037B2ec03605CFdFe482D8e257C765fA1B";
+const TIMELOCK = "0x2386DC45AdDed673317eF068992F19421B481F4c";
+const INST = "0x6f40d4A6237C257fff2dB00FA0510DeEECd303eb";
+
+const DELEGATOR = "0x5AAB0630aaCa6d0bf1c310aF6C2BB3826A951cFb";
+const PROPOSER = "0xA45f7bD6A5Ff45D31aaCE6bCD3d426D9328cea01";
+
+const LIQUIDITY = "0x52Aa899454998Be5b000Ad077a46Bbe360F4e497";
+const VAULT_FACTORY = "0x324c5Dc1fC42c7a4D43d92df1eBA58a54d13Bf2d";
+
+const weETH_ADDRESS = "0xCd5fE23C85820F7B72D0926FC9b05b43E359b7ee";
+const ETH_ADDRESS = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
+
+const VAULT_WEETH_ETH_ID = 182;
+
+/** Liquidity storage slots for the user supply / borrow double mappings. */
+const USER_SUPPLY_SLOT = 8;
+const USER_BORROW_SLOT = 9;
+
+const IGP140_PROPOSAL_ID = 140;
+const TARGET_PROPOSAL_COUNT = IGP140_PROPOSAL_ID - 1; // 139
+
+async function getProposalCount(provider: JsonRpcProvider): Promise<number> {
+  const iface = new ethers.Interface([
+    "function proposalCount() view returns (uint256)",
+  ]);
+  const result = await provider.send("eth_call", [
+    { to: GOVERNOR, data: iface.encodeFunctionData("proposalCount", []) },
+    "latest",
+  ]);
+  return Number(
+    ethers.AbiCoder.defaultAbiCoder().decode(["uint256"], result)[0],
+  );
+}
+
+async function sendTx(
+  provider: JsonRpcProvider,
+  from: string,
+  to: string,
+  data: string,
+  label: string,
+): Promise<void> {
+  const txHash = await provider.send("eth_sendTransaction", [
+    {
+      from,
+      to,
+      data,
+      value: "0x0",
+      gas: "0x989680",
+      gasPrice: "0x0",
+    },
+  ]);
+  const receipt = await provider.waitForTransaction(txHash);
+  if (!receipt || receipt.status !== 1) {
+    throw new Error(`${label} transaction failed (tx ${txHash})`);
+  }
+  console.log(`[SETUP] ${label} succeeded (${txHash})`);
+}
+
+async function delegateToProposer(provider: JsonRpcProvider): Promise<void> {
+  const delegateData = new ethers.Interface([
+    "function delegate(address delegatee)",
+  ]).encodeFunctionData("delegate", [PROPOSER]);
+  await sendTx(
+    provider,
+    DELEGATOR,
+    INST,
+    delegateData,
+    "delegate INST (delegator -> proposer) for placeholder proposals",
+  );
+}
+
+async function createDummyProposal(
+  provider: JsonRpcProvider,
+  proposalId: number,
+): Promise<void> {
+  const proposeData = new ethers.Interface([
+    "function propose(address[] targets, uint256[] values, string[] signatures, bytes[] calldatas, string description) returns (uint256)",
+  ]).encodeFunctionData("propose", [
+    [TIMELOCK],
+    [0],
+    [""],
+    ["0x"],
+    `IGP-${proposalId} placeholder (simulation only): consumes governor proposal id ${proposalId} so IGP-140 lands on id 140.`,
+  ]);
+  await sendTx(
+    provider,
+    PROPOSER,
+    GOVERNOR,
+    proposeData,
+    `create dummy IGP-${proposalId} proposal`,
+  );
+}
+
+async function ensureGovernorProposalId(
+  provider: JsonRpcProvider,
+): Promise<void> {
+  const count = await getProposalCount(provider);
+  console.log(`[SETUP] Current governor proposalCount = ${count}`);
+
+  if (count >= TARGET_PROPOSAL_COUNT) {
+    console.log(
+      `[SETUP] proposalCount (${count}) already >= ${TARGET_PROPOSAL_COUNT}; ` +
+        `IGP-140 will land on id ${count + 1}. No dummy proposal created.`,
+    );
+    return;
+  }
+
+  const needed = TARGET_PROPOSAL_COUNT - count;
+  console.log(
+    `[SETUP] Need ${needed} placeholder proposal(s) to reach proposalCount ${TARGET_PROPOSAL_COUNT}.`,
+  );
+
+  await delegateToProposer(provider);
+  for (let id = count + 1; id <= TARGET_PROPOSAL_COUNT; id++) {
+    await createDummyProposal(provider, id);
+  }
+
+  const after = await getProposalCount(provider);
+  console.log(
+    `[SETUP] proposalCount after placeholders = ${after} (next proposal -> id ${after + 1})`,
+  );
+  if (after + 1 !== IGP140_PROPOSAL_ID) {
+    throw new Error(
+      `After placeholder proposals the next id would be ${after + 1}, expected ${IGP140_PROPOSAL_ID}.`,
+    );
+  }
+}
+
+async function hasCode(
+  provider: JsonRpcProvider,
+  address: string,
+): Promise<boolean> {
+  const code = await provider.send("eth_getCode", [address, "latest"]);
+  return code !== "0x" && code !== "0x0";
+}
+
+async function getVaultAddress(
+  provider: JsonRpcProvider,
+  vaultId: number,
+): Promise<string> {
+  const iface = new ethers.Interface([
+    "function getVaultAddress(uint256 vaultId_) view returns (address)",
+  ]);
+  const result = await provider.send("eth_call", [
+    { to: VAULT_FACTORY, data: iface.encodeFunctionData("getVaultAddress", [vaultId]) },
+    "latest",
+  ]);
+  return ethers.AbiCoder.defaultAbiCoder().decode(["address"], result)[0];
+}
+
+async function getTotalVaults(provider: JsonRpcProvider): Promise<number> {
+  const iface = new ethers.Interface([
+    "function totalVaults() view returns (uint256)",
+  ]);
+  const result = await provider.send("eth_call", [
+    { to: VAULT_FACTORY, data: iface.encodeFunctionData("totalVaults", []) },
+    "latest",
+  ]);
+  return Number(
+    ethers.AbiCoder.defaultAbiCoder().decode(["uint256"], result)[0],
+  );
+}
+
+/** Liquidity `_userSupplyData` / `_userBorrowData` are `mapping(user => mapping(token => uint))`. */
+async function readUserConfig(
+  provider: JsonRpcProvider,
+  baseSlot: number,
+  user: string,
+  token: string,
+): Promise<bigint> {
+  const userSlot = ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address", "uint256"],
+      [user, baseSlot],
+    ),
+  );
+  const slot = ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address", "bytes32"],
+      [token, userSlot],
+    ),
+  );
+  const value = await provider.send("eth_getStorageAt", [
+    LIQUIDITY,
+    slot,
+    "latest",
+  ]);
+  return BigInt(value);
+}
+
+async function assertVaultDeployed(provider: JsonRpcProvider): Promise<void> {
+  const vault = await getVaultAddress(provider, VAULT_WEETH_ETH_ID);
+  const totalVaults = await getTotalVaults(provider);
+  console.log(
+    `[SETUP] Vault ${VAULT_WEETH_ETH_ID} address = ${vault} (factory totalVaults = ${totalVaults})`,
+  );
+
+  if (!(await hasCode(provider, vault))) {
+    throw new Error(
+      `Vault ${VAULT_WEETH_ETH_ID} (weETH/ETH) has no code at ${vault} on this fork ` +
+        `(totalVaults = ${totalVaults}). It was deployed on mainnet at block 25,789,585, ` +
+        `so the fork predates the deployment. Action 1 would revert at the Liquidity Layer ` +
+        `with AdminModule__AddressNotAContract (10026).`,
+    );
+  }
+  console.log(`[SETUP] Vault ${VAULT_WEETH_ETH_ID} is deployed on the fork.`);
+
+  // Informational: the payload sets these from scratch, so both should be zero.
+  const supplyConfig = await readUserConfig(
+    provider,
+    USER_SUPPLY_SLOT,
+    vault,
+    weETH_ADDRESS,
+  );
+  const borrowConfig = await readUserConfig(
+    provider,
+    USER_BORROW_SLOT,
+    vault,
+    ETH_ADDRESS,
+  );
+  if (supplyConfig !== 0n || borrowConfig !== 0n) {
+    console.warn(
+      `[SETUP] WARNING: vault ${VAULT_WEETH_ETH_ID} already has Liquidity limits configured ` +
+        `(supply=${supplyConfig !== 0n}, borrow=${borrowConfig !== 0n}). ` +
+        `IGP-140 will overwrite them with dust limits — confirm that is still intended.`,
+    );
+  } else {
+    console.log(
+      `[SETUP] Vault ${VAULT_WEETH_ETH_ID} is unconfigured at the Liquidity Layer, as expected.`,
+    );
+  }
+}
+
+export async function preSetup(
+  provider: JsonRpcProvider,
+  _payloadAddress?: string,
+): Promise<void> {
+  console.log("[SETUP] Running pre-setup for IGP140...");
+
+  try {
+    await ensureGovernorProposalId(provider);
+    await assertVaultDeployed(provider);
+
+    console.log("[SETUP] Pre-setup completed successfully");
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("[SETUP] Pre-setup failed:", message);
+    throw error;
+  }
+}
+
+export default preSetup;


### PR DESCRIPTION
Moved out of IGP-139 Action 2, which reverted the Foundation grant on execution. Two fixes over the original:

Vault auth now goes through VAULT_FACTORY_WRAPPER_OWNER instead of the vault factory. setVaultAuth is onlyOwner on the factory and the factory is owned by the wrapper, so the direct call reverted UNAUTHORIZED for the timelock. This matches how every payload since IGP-130 sets vault auth.

The pre-setup asserts vault 182 is deployed on the fork rather than assuming it. The vault landed on mainnet at block 25,789,585, hours after the IGP-139 simulation forked, and the Liquidity Layer rejects configs for an address with no code, so the original run died on the address-is-contract check before it ever reached the auth call.

Limits are unchanged from the original action ($7k withdrawal, $7k/$9k borrow, 50% over 6h). Prices are refreshed, so the token amounts differ. Verified against mainnet that all three calls succeed from the timelock, and that the vault is deployed but still unconfigured at the Liquidity Layer.

## IGP Actions

```solidity
// Action 1: Set dust limits for weETH/ETH T1 vault.
// Action 2: Reduce USDC-ETH DEX (5) max supply and borrow shares to ~$1M.
```